### PR TITLE
Add Google Publisher Tag (Google DFP)

### DIFF
--- a/tarteaucitron.services.js
+++ b/tarteaucitron.services.js
@@ -856,6 +856,28 @@ tarteaucitron.services.googlemaps = {
     }
 };
 
+// Google Publisher Tag (Google DFP)
+tarteaucitron.services.googlepublishertag = {
+    "key": "googlepublishertag",
+    "type": "ads",
+    "name": "Google Publisher Tag",
+    "uri": "https://support.google.com/dfp_premium/answer/2839090",
+    "needConsent": true,
+    "cookies": ['__gads'],
+    "js": function () {
+        "use strict";
+        tarteaucitron.addScript('//www.googletagservices.com/tag/js/gpt.js');
+    },
+    "fallback": function () {
+        "use strict";
+        var id = 'googlepublishertag';
+        
+        googletag.pubads().refresh = googletag.pubads().setCookieOptions(1);
+        
+        tarteaucitron.fallback(['setCookieOptions'], tarteaucitron.engage(id));
+    }
+};
+
 // google tag manager
 tarteaucitron.services.googletagmanager = {
     "key": "googletagmanager",


### PR DESCRIPTION
Bonjour,

Je me permets de suggérer l'ajout de Google Publisher Tag (Google DFP).

```
/**
 *  La valeur "1" pour le paramètre relatif aux options pour ignorer les cookies.
 *  googletag.pubads().setCookieOptions(1);
 **/
```

D'après mes tests cela fonctionne comme ça mais je ne suis pas très à l'aise avec JS.

Quelques infos supplémentaires sont disponibles (https://support.google.com/dfp_premium/answer/3202794?hl=fr ) pour ajouter dans
son code cette partie :
googletag.pubads().setCookieOptions(0);

Et le script à ajouter :

<script type="text/javascript">
(tarteaucitron.job = tarteaucitron.job || []).push('googlepublishertag');
</script>


Peut être qu'il y a une autre méthode ?
