### PR TITLE
 	Ajout de la like-box pour les pages Facebook (fb-page)

### DIFF
--- a/tarteaucitron.js
+++ b/tarteaucitron.js
@@ -411,11 +411,11 @@ var tarteaucitron = {
             html += '   <div class="tarteaucitronName">';
             html += '       <b>' + service.name + '</b><br/>';
             html += '       <span id="tacCL' + service.key + '" class="tarteaucitronListCookies"></span><br/>';
-            html += '       <a href="https://opt-out.ferank.eu/service/' + service.key + '/" target="_blank">';
+            html += '       <a href="https://opt-out.ferank.eu/service/' + service.key + '/" target="_blank" rel="nofollow">';
             html += '           ' + tarteaucitron.lang.more;
             html += '       </a>';
             html += '        - ';
-            html += '       <a href="' + service.uri + '" target="_blank">';
+            html += '       <a href="' + service.uri + '" target="_blank" rel="nofollow">';
             html += '           ' + tarteaucitron.lang.source;
             html += '       </a>';
             html += '   </div>';

--- a/tarteaucitron.services.js
+++ b/tarteaucitron.services.js
@@ -490,7 +490,7 @@ tarteaucitron.services.facebook = {
     "js": function () {
         "use strict";
         tarteaucitron.fallback(['fb-post', 'fb-follow', 'fb-activity', 'fb-send', 'fb-share-button', 'fb-like'], '');
-        tarteaucitron.addScript('//connect.facebook.net/' + tarteaucitron.getLocale() + '/sdk.js#xfbml=1&version=v2.0', 'facebook-jssdk');
+        tarteaucitron.addScript('//connect.facebook.net/' + tarteaucitron.getLocale() + '/sdk.js#xfbml=1&version=v2.6', 'facebook-jssdk');
         if (tarteaucitron.isAjax === true) {
             if (typeof FB !== "undefined") {
                 FB.XFBML.parse();
@@ -515,7 +515,7 @@ tarteaucitron.services.facebooklikebox = {
     "js": function () {
         "use strict";
         tarteaucitron.fallback(['fb-like-box'], '');
-        tarteaucitron.addScript('//connect.facebook.net/' + tarteaucitron.getLocale() + '/sdk.js#xfbml=1&version=v2.0', 'facebook-jssdk');
+        tarteaucitron.addScript('//connect.facebook.net/' + tarteaucitron.getLocale() + '/sdk.js#xfbml=1&version=v2.6', 'facebook-jssdk');
         if (tarteaucitron.isAjax === true) {
             if (typeof FB !== "undefined") {
                 FB.XFBML.parse();
@@ -540,7 +540,7 @@ tarteaucitron.services.facebooklikeboxforpage = {
     "js": function () {
         "use strict";
         tarteaucitron.fallback(['fb-page'], '');
-        tarteaucitron.addScript('//connect.facebook.net/' + tarteaucitron.getLocale() + '/sdk.js#xfbml=1&version=v2.3', 'facebook-jssdk');
+        tarteaucitron.addScript('//connect.facebook.net/' + tarteaucitron.getLocale() + '/sdk.js#xfbml=1&version=v2.6', 'facebook-jssdk');
         if (tarteaucitron.isAjax === true) {
             if (typeof FB !== "undefined") {
                 FB.XFBML.parse();


### PR DESCRIPTION
bonjour,

ajout de la likebox facebook pour les pages facebook qui utilise la version 2.3 de l'API facebook et l'id "fb-page".

(tarteaucitron.job = tarteaucitron.job || []).push('facebooklikeboxforpage');

Cordialement,

Eric
