### PR TITLE
Add _gat_gtag_UA cookie to gtag cookies array

### DIFF
--- a/tarteaucitron.services.js
+++ b/tarteaucitron.services.js
@@ -875,6 +875,11 @@ tarteaucitron.services.gtag = {
     "js": function () {
         "use strict";
         window.dataLayer = window.dataLayer || [];
+
+        // Add _gat_gtag_UA_XXXXXXX_XX cookie to cookies array
+        var gatGtagUaCookie = '_gat_gtag_' + tarteaucitron.user.gtagUa;
+        gatGtagUaCookie = gatGtagUaCookie.replace(/-/g, '_');
+        this.cookies.push(gatGtagUaCookie);
         
         tarteaucitron.addScript('//www.googletagmanager.com/gtag/js?id=' + tarteaucitron.user.gtagUa, '', function () {
             function gtag(){dataLayer.push(arguments);}


### PR DESCRIPTION
Hi

With Google Analytics gtag I am seeing a cookie _gat_gtag_UA_XXXXXXX_XX being created but not deleted by your library.

In the code attached I have pushed this cookie into the _tarteaucitron.services.gtag.cookies_ array so it gets purged when the purge function is called.

Excellant library thanks