### PR TITLE
Added iframe google maps with search query + customization cookie expire

### DIFF
--- a/tarteaucitron.js
+++ b/tarteaucitron.js
@@ -6,6 +6,8 @@ var scripts = document.getElementsByTagName('script'),
     cdn = path.split('/').slice(0, -1).join('/') + '/',
     alreadyLaunch = (alreadyLaunch === undefined) ? 0 : alreadyLaunch,
     tarteaucitronForceLanguage = (tarteaucitronForceLanguage === undefined) ? '' : tarteaucitronForceLanguage,
+    tarteaucitronForceExpire = (tarteaucitronForceExpire === undefined) ? '' : tarteaucitronForceExpire,
+    timeExipre = 31536000000,
     tarteaucitronProLoadServices,
     tarteaucitronNoAdBlocker = false;
 
@@ -860,9 +862,15 @@ var tarteaucitron = {
         "owner": {},
         "create": function (key, status) {
             "use strict";
+
+            if (tarteaucitronForceExpire !== '') {
+                // The number of day cann't be higher than 1 year
+                timeExipre = (tarteaucitronForceExpire > 365) ? 31536000000 : tarteaucitronForceExpire * 86400000; // Multiplication to tranform the number of days to milliseconds
+            }
+
             var d = new Date(),
                 time = d.getTime(),
-                expireTime = time + 31536000000, // 365 days
+                expireTime = time + timeExipre, // 365 days
                 regex = new RegExp("!" + key + "=(wait|true|false)", "g"),
                 cookie = tarteaucitron.cookie.read().replace(regex, ""),
                 value = 'tarteaucitron=' + cookie + '!' + key + '=' + status,

--- a/tarteaucitron.services.js
+++ b/tarteaucitron.services.js
@@ -937,6 +937,38 @@ tarteaucitron.services.googlemaps = {
     }
 };
 
+// googlemaps search
+tarteaucitron.services.googlemapssearch = {
+    "key": "googlemapssearch",
+    "type": "api",
+    "name": "Google Maps Seard API",
+    "uri": "http://www.google.com/ads/preferences/",
+    "needConsent": true,
+    "cookies": ['nid'],
+    "js": function () {
+        "use strict";
+        tarteaucitron.fallback(['googlemapssearch'], function (x) {
+            var width = x.getAttribute("width"),
+                height = x.getAttribute("height"),
+                // url = x.getAttribute("data-url");
+                query = escape(x.getAttribute("data-search")),
+                key = x.getAttribute("data-api-key");
+            
+            // return '<iframe src="' + url + '" width="' + width + '" height="' + height + '" frameborder="0" scrolling="no" allowtransparency allowfullscreen></iframe>';
+            return '<iframe width="' + width +'" height="' + height + '" frameborder="0" style="border:0" src="https://www.google.com/maps/embed/v1/place?q='+query+'&key='+key+'" allowfullscreen></iframe> '
+        });
+    },
+    "fallback": function () {
+        "use strict";
+        var id = 'googlemapssearch';
+        tarteaucitron.fallback(['googlemapssearch'], function (elem) {
+            elem.style.width = elem.getAttribute('width') + 'px';
+            elem.style.height = elem.getAttribute('height') + 'px';
+            return tarteaucitron.engage(id);
+        });
+    }
+};
+
 // google tag manager
 tarteaucitron.services.googletagmanager = {
     "key": "googletagmanager",


### PR DESCRIPTION
I needed the google maps embed but not only with the coordinate but with a search query.
I copied and modified the iframe section, but I hope that this will be merged and useful for other people.


1.  Add this :
`(tarteaucitron.job = tarteaucitron.job || []).push('googlemapssearch');`

2. Replacement code :
`<div class="googlemapssearch" data-search="gare du midi bruxelles" data-api-key="YOUR_GOOGLE_MAP_API_KEY" width="100%" height="600" ></div>`

3. Service marker (delete if installed)
`<iframe width="600" height="450" frameborder="0" style="border:0"
  src="https://www.google.com/maps/embed/v1/place?key=YOUR_API_KEY&q=Space+Needle,Seattle+WA" allowfullscreen> </iframe>`

Thank you very much for the good work that you have done!