### PR TITLE
Allow tarteaucitronAlertSmall to be at top when orientation is set to top.

### DIFF
--- a/css/tarteaucitron.css
+++ b/css/tarteaucitron.css
@@ -364,9 +364,17 @@
 /***
  * Small alert
  */
+
+.tarteaucitronAlertSmallTop {
+    top: 0;
+}
+
+.tarteaucitronAlertSmallBottom {
+    bottom: 0;
+}
+
 #tarteaucitronAlertSmall {
     background: #333;
-    bottom: 0;
     display: none;
     padding: 0;
     position: fixed;

--- a/tarteaucitron.js
+++ b/tarteaucitron.js
@@ -296,7 +296,7 @@ var tarteaucitron = {
                 }
                 
                 if (defaults.showAlertSmall === true) {
-                    html += '<div id="tarteaucitronAlertSmall">';
+                    html += '<div id="tarteaucitronAlertSmall" class="tarteaucitronAlertSmall' + orientation + '">';
                     html += '   <div id="tarteaucitronManager" onclick="tarteaucitron.userInterface.openPanel();">';
                     html += '       ' + tarteaucitron.lang.alertSmall;
                     html += '       <div id="tarteaucitronDot">';


### PR DESCRIPTION
Hello,

On mobile device, when Adsense Auto Ads is in use, and orientation to bottom, the small alert should be behind ads.

This allow alert to be at top and unhide it.

Thanks,

Eric