### PR TITLE
add DNT DoNotTrack Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ tarteaucitron.init({
     "showAlertSmall": true, /* afficher le petit bandeau en bas à droite ? */
     "cookieslist": true, /* Afficher la liste des cookies installés ? */
     "removeCredit": false, /* supprimer le lien vers la source ? */
+    "handleBrowserDNTRequest": false, /* Répondre au DoNotTrack du navigateur ?*/
     "cookieDomain": ".my-multisite-domaine.fr" /* Nom de domaine sur lequel sera posé le cookie - pour les multisites / sous-domaines - Facultatif */
 });
 </script>

--- a/tarteaucitron.js
+++ b/tarteaucitron.js
@@ -183,7 +183,8 @@ var tarteaucitron = {
                 "orientation": "top",
                 "removeCredit": false,
                 "showAlertSmall": true,
-                "cookieslist": true
+                "cookieslist": true,
+                "handleBrowserDNTRequest": false
             },
             params = tarteaucitron.parameters;
         
@@ -196,6 +197,7 @@ var tarteaucitron = {
         tarteaucitron.orientation = defaults.orientation;
         tarteaucitron.hashtag = defaults.hashtag;
         tarteaucitron.highPrivacy = defaults.highPrivacy;
+        tarteaucitron.handleBrowserDNTRequest = defaults.handleBrowserDNTRequest;
 
         // Step 1: load css
         linkElement.rel = 'stylesheet';
@@ -463,7 +465,7 @@ var tarteaucitron = {
             }
             tarteaucitron.state[service.key] = false;
             tarteaucitron.userInterface.color(service.key, false);
-        } else if (!isResponded && isDNTRequested) {
+        } else if (!isResponded && isDNTRequested && tarteaucitron.handleBrowserDNTRequest) {
             tarteaucitron.cookie.create(service.key, 'false');
             if (typeof service.fallback === 'function') {
                 service.fallback();

--- a/tarteaucitron.js
+++ b/tarteaucitron.js
@@ -405,6 +405,7 @@ var tarteaucitron = {
             isDenied = (cookie.indexOf(service.key + '=false') >= 0) ? true : false,
             isAllowed = (cookie.indexOf(service.key + '=true') >= 0) ? true : false,
             isResponded = (cookie.indexOf(service.key + '=false') >= 0 || cookie.indexOf(service.key + '=true') >= 0) ? true : false;
+            isDNTRequested = (navigator.doNotTrack === "1" || navigator.doNotTrack === "yes" || navigator.msDoNotTrack === "1" || window.doNotTrack === "1") ? true : false;
 
         if (tarteaucitron.added[service.key] !== true) {
             tarteaucitron.added[service.key] = true;
@@ -457,6 +458,13 @@ var tarteaucitron = {
             tarteaucitron.state[service.key] = true;
             tarteaucitron.userInterface.color(service.key, true);
         } else if (isDenied) {
+            if (typeof service.fallback === 'function') {
+                service.fallback();
+            }
+            tarteaucitron.state[service.key] = false;
+            tarteaucitron.userInterface.color(service.key, false);
+        } else if (!isResponded && isDNTRequested) {
+            tarteaucitron.cookie.create(service.key, 'false');
             if (typeof service.fallback === 'function') {
                 service.fallback();
             }


### PR DESCRIPTION
Hello,
When browser make request with DNT header set to yes or 1, set all services to false
and service.fallback if needed. tarteaucitronAlertBig is not displayed/needed
but tarteaucitronAlertSmall is.
Thanks
https://github.com/AmauriC/tarteaucitron.js/issues/78

PS : it should be more explicit to user to add some words in the settings panel, and/or one icon to tarteauCitronAlertSmall. 

@bleutzinn @chaissac
