### PR TITLE
Ajout d'un service pour Google Analytics on Steroids

### DIFF
--- a/tarteaucitron.services.js
+++ b/tarteaucitron.services.js
@@ -711,7 +711,7 @@ tarteaucitron.services.facebook = {
     "cookies": [],
     "js": function () {
         "use strict";
-        tarteaucitron.fallback(['fb-post', 'fb-follow', 'fb-activity', 'fb-send', 'fb-share-button', 'fb-like'], '');
+        tarteaucitron.fallback(['fb-post', 'fb-follow', 'fb-activity', 'fb-send', 'fb-share-button', 'fb-like', 'fb-video'], '');
         tarteaucitron.addScript('//connect.facebook.net/' + tarteaucitron.getLocale() + '/sdk.js#xfbml=1&version=v2.0', 'facebook-jssdk');
         if (tarteaucitron.isAjax === true) {
             if (typeof FB !== "undefined") {
@@ -722,7 +722,7 @@ tarteaucitron.services.facebook = {
     "fallback": function () {
         "use strict";
         var id = 'facebook';
-        tarteaucitron.fallback(['fb-post', 'fb-follow', 'fb-activity', 'fb-send', 'fb-share-button', 'fb-like'], tarteaucitron.engage(id));
+        tarteaucitron.fallback(['fb-post', 'fb-follow', 'fb-activity', 'fb-send', 'fb-share-button', 'fb-like', 'fb-video'], tarteaucitron.engage(id));
     }
 };
 

--- a/tarteaucitron.services.js
+++ b/tarteaucitron.services.js
@@ -1030,6 +1030,38 @@ tarteaucitron.services.gajs = {
     }
 };
 
+// google on steroids
+var _gas = _gas || [];
+tarteaucitron.services.gas = {
+    "key": "gas",
+    "type": "analytic",
+    "name": "Google Analytics on Steroids",
+    "uri": "https://github.com/CardinalPath/gas",
+    "needConsent": true,
+    "cookies": ['_ga', '_gat', '_gid', '__utma', '__utmb', '__utmc', '__utmt', '__utmz'],
+    "js": function () {
+        "use strict";
+        _gas.push(['_setAccount', tarteaucitron.user.gasUa]); // REPLACE WITH YOUR GA NUMBER
+        _gas.push(['_setDomainName', tarteaucitron.parameters.cookieDomain]); // REPLACE WITH YOUR DOMAIN
+        _gas.push(['_trackPageview']);
+        _gas.push(['_gasTrackForms']);
+        _gas.push(['_gasTrackOutboundLinks']);
+        _gas.push(['_gasTrackMaxScroll']);
+        _gas.push(['_gasTrackDownloads']);
+        _gas.push(['_gasTrackVideo']);
+        _gas.push(['_gasTrackAudio']);
+        _gas.push(['_gasTrackYoutube', {force: true}]);
+        _gas.push(['_gasTrackVimeo', {force: true}]);
+        _gas.push(['_gasTrackMailto']);
+
+        tarteaucitron.addScript('//cdnjs.cloudflare.com/ajax/libs/gas/1.11.0/gas.min.js', 'gas-script', function () {
+            if (typeof tarteaucitron.user.gasMore === 'function') {
+                tarteaucitron.user.gasMore();
+            }
+        },'','data-use-dcjs','false');
+    }
+};
+
 // google analytics
 tarteaucitron.services.analytics = {
     "key": "analytics",
@@ -2165,3 +2197,4 @@ tarteaucitron.services.webmecanik = {
         });
     }
 };
+


### PR DESCRIPTION
Google Analytics On Steroid est un wrapper ajoutant des fonctionnalités tels que le tracking des fichiers téléchargés pour Google Analytics.

Nous avons eu besoin d'ajouter ce service pour l'un de nos projets.

Voir : https://github.com/CardinalPath/gas