### PR TITLE
Added matomo service [Working] without merge conflict

### DIFF
--- a/tarteaucitron.services.js
+++ b/tarteaucitron.services.js
@@ -2200,3 +2200,44 @@ tarteaucitron.services.multiplegtag = {
     }
 };
 
+// matomo
+
+/*
+    1. Set the following variable before the initialization :
+
+    tarteaucitron.user.matomoId = YOUR_SITE_ID_FROM_MATOMO;
+    tarteaucitron.user.matomoHost = "YOUR_MATOMO_URL"; //eg: https://stat.mydomain.com/
+
+    2. Push the service :
+
+    (tarteaucitron.job = tarteaucitron.job || []).push('matomo');
+
+    3. HTML
+    You don't need to add any html code, if the service is autorized, the javascript is added. otherwise no.
+ */
+tarteaucitron.services.matomo = {
+    "key": "matomo",
+    "type": "analytic",
+    "name": "Matomo (formerly known as Piwik)",
+    "uri": "https://matomo.org/faq/general/faq_146/",
+    "needConsent": true,
+    "cookies": ['_pk_ref', '_pk_cvar', '_pk_id', '_pk_ses', '_pk_hsr', 'piwik_ignore', '_pk_uid'],
+    "js": function () {
+        "use strict";
+        console.log("matomo");
+        if (tarteaucitron.user.matomoId === undefined) {
+            return;
+        }
+
+        window._paq = window._paq || [];
+        window._paq.push(["setSiteId", tarteaucitron.user.matomoId]);
+        window._paq.push(["setTrackerUrl", tarteaucitron.user.matomoHost + "piwik.php"]);
+        window._paq.push(["setDoNotTrack", 1]);
+        window._paq.push(["trackPageView"]);
+        window._paq.push(["setIgnoreClasses", ["no-tracking", "colorbox"]]);
+        window._paq.push(["enableLinkTracking"]);
+
+        tarteaucitron.addScript(tarteaucitron.user.matomoHost + 'piwik.js', '', '', true, 'defer', true);
+    }
+};
+

--- a/tarteaucitron.services.js
+++ b/tarteaucitron.services.js
@@ -2224,7 +2224,6 @@ tarteaucitron.services.matomo = {
     "cookies": ['_pk_ref', '_pk_cvar', '_pk_id', '_pk_ses', '_pk_hsr', 'piwik_ignore', '_pk_uid'],
     "js": function () {
         "use strict";
-        console.log("matomo");
         if (tarteaucitron.user.matomoId === undefined) {
             return;
         }


### PR DESCRIPTION
I created a new pull request to add matomo/piwik to the service of tarteaucitron.js. 
I will need it very soon and I don't know how to modify the previous merge request #107 that doesn't work for me.


 1. Set the following variable before the initialization :
```javascript
    tarteaucitron.user.matomoId = YOUR_SITE_ID_FROM_MATOMO;
    tarteaucitron.user.matomoHost = "YOUR_MATOMO_URL"; //eg: https://stat.mydomain.com/
```
   

2. Push the service :
```javascript
        (tarteaucitron.job = tarteaucitron.job || []).push('matomo');
```
3. HTML
    You don't need to add any html code, if the service is autorized, the javascript is added. otherwise no.