### PR TITLE
Gtag variable should be set in global scope for later use

### DIFF
--- a/tarteaucitron.services.js
+++ b/tarteaucitron.services.js
@@ -1073,7 +1073,7 @@ tarteaucitron.services.gtag = {
         "use strict";
         window.dataLayer = window.dataLayer || [];
         tarteaucitron.addScript('https://www.googletagmanager.com/gtag/js?id=' + tarteaucitron.user.gtagUa, '', function () {
-            function gtag(){dataLayer.push(arguments);}
+            window.gtag = function gtag(){dataLayer.push(arguments);}
             gtag('js', new Date());
             gtag('config', tarteaucitron.user.gtagUa);
 


### PR DESCRIPTION
The gtag function is not usable in gtagMore() or anywhere outside the closure scope.