### PR TITLE
Make automatic triggering of js scripts optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,8 @@ tarteaucitron.init({
     "cookieslist": true, /* Afficher la liste des cookies installés ? */
     "removeCredit": false, /* supprimer le lien vers la source ? */
     "handleBrowserDNTRequest": false, /* Répondre au DoNotTrack du navigateur ?*/
-    "cookieDomain": ".my-multisite-domaine.fr" /* Nom de domaine sur lequel sera posé le cookie - pour les multisites / sous-domaines - Facultatif */
+    "cookieDomain": ".my-multisite-domaine.fr", /* Nom de domaine sur lequel sera posé le cookie - pour les multisites / sous-domaines - Facultatif */
+    "executeScripts": true /* Execute les scripts JS automatiquement lorsque les cookies sont acceptés ?*/
 });
 </script>
 ```

--- a/tarteaucitron.js
+++ b/tarteaucitron.js
@@ -186,7 +186,8 @@ var tarteaucitron = {
                 "removeCredit": false,
                 "showAlertSmall": true,
                 "cookieslist": true,
-                "handleBrowserDNTRequest": false
+                "handleBrowserDNTRequest": false,
+                "executeScripts": true
             },
             params = tarteaucitron.parameters;
         
@@ -460,7 +461,9 @@ var tarteaucitron = {
             }
             if (tarteaucitron.launch[service.key] !== true) {
                 tarteaucitron.launch[service.key] = true;
-                service.js();
+                if (tarteaucitron.parameters.executeScripts) {
+                    service.js();
+                }
             }
             tarteaucitron.state[service.key] = true;
             tarteaucitron.userInterface.color(service.key, true);
@@ -536,7 +539,9 @@ var tarteaucitron = {
                     }
                     if (tarteaucitron.launch[key] !== true && status === true) {
                         tarteaucitron.launch[key] = true;
-                        tarteaucitron.services[key].js();
+                        if (tarteaucitron.parameters.executeScripts) {
+                            tarteaucitron.services[key].js();
+                        }
                     }
                     tarteaucitron.state[key] = status;
                     tarteaucitron.cookie.create(key, status);
@@ -561,7 +566,9 @@ var tarteaucitron = {
             if (status === true) {
                 if (tarteaucitron.launch[key] !== true) {
                     tarteaucitron.launch[key] = true;
-                    tarteaucitron.services[key].js();
+                    if (tarteaucitron.parameters.executeScripts) {
+                        tarteaucitron.services[key].js();
+                    }
                 }
             }
             tarteaucitron.state[key] = status;


### PR DESCRIPTION
For one of our projects, we would like to use tarteaucitron because it's very easy to use and give already the banner and the popin linked to a technical cookie. 

However, we don't want tarteaucitron to trigger itself the scripts as a tag container. To do that, we want to use Google Tag Manager which gives more flexibility. Therefore, we suggest to make the triggering of the scripts optional, and active by default.

The only thing to do is add the following parameter to disable the execution of the scripts:

`"executeScripts": false`