### PR TITLE
Allow to force CDN

### DIFF
--- a/tarteaucitron.js
+++ b/tarteaucitron.js
@@ -3,7 +3,7 @@
 // define correct path for files inclusion
 var scripts = document.getElementsByTagName('script'),
     path = scripts[scripts.length - 1].src.split('?')[0],
-    cdn = path.split('/').slice(0, -1).join('/') + '/',
+    cdn = (tarteaucitronForceCDN === undefined) ? path.split('/').slice(0, -1).join('/') + '/' : tarteaucitronForceCDN,
     alreadyLaunch = (alreadyLaunch === undefined) ? 0 : alreadyLaunch,
     tarteaucitronForceLanguage = (tarteaucitronForceLanguage === undefined) ? '' : tarteaucitronForceLanguage,
     tarteaucitronForceExpire = (tarteaucitronForceExpire === undefined) ? '' : tarteaucitronForceExpire,


### PR DESCRIPTION
Let me argue why this feature is useful. `tarteaucitron.js` does a good job loading almost every other file asynchronously. However the documentation tells users to load `tarteaucitron.js` synchronously which blocks everything else.

I decided to inline `tarteaucitron.js`. This raised an error, as it lost the ability to locate the rest of the project files. This option allows to set the cdn path manually in order to solve the error.