### PR TITLE
Fix #197 tarteaucitronForceCDN always defined

### DIFF
--- a/tarteaucitron.js
+++ b/tarteaucitron.js
@@ -3,7 +3,8 @@
 // define correct path for files inclusion
 var scripts = document.getElementsByTagName('script'),
     path = scripts[scripts.length - 1].src.split('?')[0],
-    cdn = (tarteaucitronForceCDN === undefined) ? path.split('/').slice(0, -1).join('/') + '/' : tarteaucitronForceCDN,
+    tarteaucitronForceCDN = (tarteaucitronForceCDN === undefined) ? '' : tarteaucitronForceCDN,
+    cdn = (tarteaucitronForceCDN === '') ? path.split('/').slice(0, -1).join('/') + '/' : tarteaucitronForceCDN,
     alreadyLaunch = (alreadyLaunch === undefined) ? 0 : alreadyLaunch,
     tarteaucitronForceLanguage = (tarteaucitronForceLanguage === undefined) ? '' : tarteaucitronForceLanguage,
     tarteaucitronForceExpire = (tarteaucitronForceExpire === undefined) ? '' : tarteaucitronForceExpire,


### PR DESCRIPTION
Make sure that `tarteaucitronForceCDN` is always defined. If underfined convert to empty string. When defining `cdn`, use default cdn if `tarteaucitronForceCDN` is an empty string.