### PR TITLE
Add support for analytics pre-pageview userland logic

### DIFF
--- a/tarteaucitron.services.js
+++ b/tarteaucitron.services.js
@@ -1064,6 +1064,10 @@ tarteaucitron.services.analytics = {
                 ga('set', 'anonymizeIp', true);
             }
 
+            if (typeof tarteaucitron.user.analyticsPrepare === 'function') {
+                tarteaucitron.user.analyticsPrepare();
+            }
+
             if (tarteaucitron.user.analyticsPageView) {
                 ga('send', 'pageview', tarteaucitron.user.analyticsPageView);
             } else {


### PR DESCRIPTION
It allows to prepare data sent during pageview, for instance
`ec:setAction` for enhanced e-commerce analytics.