### PR TITLE
✨ Add Google Maps Iframe embed service

### DIFF
--- a/tarteaucitron.js
+++ b/tarteaucitron.js
@@ -1447,5 +1447,11 @@ var tarteaucitron = {
             }
         }
         return source;
+    },
+    "getElemWidth": function(elem) {
+        return elem.getAttribute('width') || elem.clientWidth;
+    },
+    "getElemHeight": function(elem) {
+        return elem.getAttribute('height') || elem.clientHeight;
     }
 };

--- a/tarteaucitron.services.js
+++ b/tarteaucitron.services.js
@@ -1191,6 +1191,35 @@ tarteaucitron.services.googlemapssearch = {
     }
 };
 
+// googlemaps embed iframe
+tarteaucitron.services.googlemapsembed = {
+    "key": "googlemapsembed",
+    "type": "api",
+    "name": "Google Maps Embed",
+    "uri": "http://www.google.com/ads/preferences/",
+    "needConsent": true,
+    "cookies": ['apisid', 'hsid', 'nid', 'sapisid', 'sid', 'sidcc', 'ssid', '1p_jar'],
+    "js": function () {
+        "use strict";
+        tarteaucitron.fallback(['googlemapsembed'], function (x) {
+            var width = tarteaucitron.getElemWidth(x),
+                height = tarteaucitron.getElemHeight(x),
+                url = x.getAttribute("data-url");
+
+            return '<iframe src="' + url + '" width="' + width + '" height="' + height + '" frameborder="0" scrolling="no" allowtransparency allowfullscreen></iframe>';
+        });
+    },
+    "fallback": function () {
+        "use strict";
+        var id = 'googlemapsembed';
+        tarteaucitron.fallback(['googlemapsembed'], function (elem) {
+            elem.style.width = tarteaucitron.getElemWidth(elem) + 'px';
+            elem.style.height = tarteaucitron.getElemHeight(elem) + 'px';
+            return tarteaucitron.engage(id);
+        });
+    }
+};
+
 // google tag manager
 tarteaucitron.services.googletagmanager = {
     "key": "googletagmanager",


### PR DESCRIPTION
I needed to use the embeded maps iframes so I created a new service for them. 

It allows you yo use this kind of iframes: 
```
<iframe src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d11245.704052781535!2d5.7165677990487485!3d45.198714183514454!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x478af4630377eae5%3A0x38510a9930381add!2sFort+de+La+Bastille!5e0!3m2!1sfr!2sfr!4v1536919770110" width="600" height="450" frameborder="0" style="border:0" allowfullscreen></iframe>
```

by calling 
```
<div class="googlemapsembed" data-url="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d11245.704052781535!2d5.7165677990487485!3d45.198714183514454!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x478af4630377eae5%3A0x38510a9930381add!2sFort+de+La+Bastille!5e0!3m2!1sfr!2sfr!4v153691977011">
</div>
```

It's like some generic iframe but with specific cookies/authorizations.

I also created `tarteaucitron.getElemWidth` and  `tarteaucitron.getElemHeight` so width/height are calculated from nodes if not given as arguments.