### PR TITLE
AT Internet SmartTag integration

### DIFF
--- a/tarteaucitron.services.js
+++ b/tarteaucitron.services.js
@@ -1994,6 +1994,28 @@ tarteaucitron.services.xiti = {
     }
 };
 
+// AT Internet
+tarteaucitron.services.atinternet = {
+    "key": "atinternet",
+    "type": "analytic",
+    "name": "AT Internet",
+    "uri": "http://www.atinternet.com/politique-du-respect-de-la-vie-privee/",
+    "needConsent": true,
+    "cookies": ['atidvisitor', 'atreman', 'atredir', 'atsession', 'atuserid'],
+    "js": function () {
+        "use strict";
+        if (tarteaucitron.user.atLibUrl === undefined) {
+            return;
+        }
+
+        tarteaucitron.addScript(tarteaucitron.user.atLibUrl, '', function() {
+            if (typeof tarteaucitron.user.atMore === 'function') {
+                tarteaucitron.user.atMore();
+            }
+        })
+    }
+};
+
 // youtube
 tarteaucitron.services.youtube = {
     "key": "youtube",


### PR DESCRIPTION
# AT Internet SmartTag integration

This PR aims to give a way to use AT Internet latest lib with tarteaucitron.

## Installation

Add this service declaration

```javascript
tarteaucitron.user.atLibUrl = '//tag.aticdn.net/XXXXXX/smarttag.js';
tarteaucitron.user.atMore = function () { 
	/* your AT Internet tagging */
};
(tarteaucitron.job = tarteaucitron.job || []).push('atinternet');
```

### Parameters

- `atLibUrl` link to your smarttag.js file (either locally or on AT Internet CDN)

```javascript
// CDN file
tarteaucitron.user.atLibUrl = '//tag.aticdn.net/XXXXXX/smarttag.js';
// local file
tarteaucitron.user.atLibUrl = '/js/smarttag.js';
```

- `atMore` your AT Internet tagging

```javascript
tarteaucitron.user.atMore = function () { 
  var ATTag = new ATInternet.Tracker.Tag();
  ATTag.page.set({
    name:'pageName'
  });
  ATTag.dispatch();
}
```

---

Regarding the addition to the tarteaucitron website (in the installation guide), I can't find how to do it. Would it be possible to replace Xiti installation with this one? (Xiti service is outdated and won't work for most our our customers)

Regards,
Benjamin