### PR TITLE
Remove the hardcoded colors from the JS

### DIFF
--- a/css/tarteaucitron.css
+++ b/css/tarteaucitron.css
@@ -744,7 +744,7 @@ div.amazon_product {
 
 div#tarteaucitronInfo {
     display: block!important;
-    position: initial!important;
+    position: relative;
     text-align: center!important;
     max-width: 80%!important;
     padding: 15px 0!important;

--- a/css/tarteaucitron.css
+++ b/css/tarteaucitron.css
@@ -371,6 +371,14 @@ div#tarteaucitronServices {
     padding: 15px 5px;
 }
 
+#tarteaucitron #tarteaucitronServices .tarteaucitronLine.tarteaucitronIsAllowed {
+    border-color: #1B870B;
+}
+
+#tarteaucitron #tarteaucitronServices .tarteaucitronLine.tarteaucitronIsDenied {
+    border-color: #9C1A1A;
+}
+
 #tarteaucitron #tarteaucitronServices .tarteaucitronMainLine {
     background: #333;
     border: 3px solid #333;
@@ -430,6 +438,22 @@ div#tarteaucitronServices {
     text-decoration: none;
     width: auto;
     border: 0;
+}
+
+#tarteaucitron #tarteaucitronServices #tarteaucitronAllAllowed.tarteaucitronIsSelected {
+    background-color: #1B870B;
+    opacity: 1;
+}
+#tarteaucitron #tarteaucitronServices #tarteaucitronAllDenied.tarteaucitronIsSelected {
+    background-color: #9C1A1A;
+    opacity: 1;
+}
+
+#tarteaucitron #tarteaucitronServices .tarteaucitronLine.tarteaucitronIsAllowed .tarteaucitronAllow {
+    background-color: #1B870B;
+}
+#tarteaucitron #tarteaucitronServices .tarteaucitronLine.tarteaucitronIsDenied .tarteaucitronDeny {
+    background-color: #9C1A1A;
 }
 
 #tarteaucitron #tarteaucitronServices .tarteaucitronLine .tarteaucitronName .tarteaucitronListCookies {
@@ -714,7 +738,7 @@ div.amazon_product {
 }.tarteaucitronIsDenied .tarteaucitronDeny {
     opacity: 1!important;
 }
-.tarteaucitronLine .tarteaucitronAllow, .tarteaucitronLine .tarteaucitronAllow {
+.tarteaucitronLine .tarteaucitronAllow, .tarteaucitronLine .tarteaucitronDeny {
     opacity: 0.4;
 }
 

--- a/tarteaucitron.js
+++ b/tarteaucitron.js
@@ -16,7 +16,7 @@ var scripts = document.getElementsByTagName('script'),
 
 
 var tarteaucitron = {
-    "version": 20181023,
+    "version": 20181120,
     "cdn": cdn,
     "user": {},
     "lang": {},
@@ -672,13 +672,7 @@ var tarteaucitron = {
         },
         "color": function (key, status) {
             "use strict";
-            var gray = '#808080',
-                greenDark = '#1B870B',
-                greenLight = '#E6FFE2',
-                redDark = '#9C1A1A',
-                redLight = '#FFE2E2',
-                yellowDark = '#FBDA26',
-                c = 'tarteaucitron',
+            var c = 'tarteaucitron',
                 nbDenied = 0,
                 nbPending = 0,
                 nbAllowed = 0,
@@ -686,17 +680,9 @@ var tarteaucitron = {
                 index;
 
             if (status === true) {
-                tarteaucitron.userInterface.css(key + 'Line', 'borderLeft', '5px solid ' + greenDark);
-                tarteaucitron.userInterface.css(key + 'Allowed', 'backgroundColor', greenDark);
-                tarteaucitron.userInterface.css(key + 'Denied', 'backgroundColor', gray);
-
                 document.getElementById(key + 'Line').classList.add('tarteaucitronIsAllowed');
                 document.getElementById(key + 'Line').classList.remove('tarteaucitronIsDenied');
             } else if (status === false) {
-                tarteaucitron.userInterface.css(key + 'Line', 'borderLeft', '5px solid ' + redDark);
-                tarteaucitron.userInterface.css(key + 'Allowed', 'backgroundColor', gray);
-                tarteaucitron.userInterface.css(key + 'Denied', 'backgroundColor', redDark);
-
                 document.getElementById(key + 'Line').classList.remove('tarteaucitronIsAllowed');
                 document.getElementById(key + 'Line').classList.add('tarteaucitronIsDenied');
             }
@@ -717,16 +703,14 @@ var tarteaucitron = {
             tarteaucitron.userInterface.css(c + 'DotRed', 'width', ((100 / sum) * nbDenied) + '%');
 
             if (nbDenied === 0 && nbPending === 0) {
-                tarteaucitron.userInterface.css(c + 'AllAllowed', 'backgroundColor', greenDark);
-                tarteaucitron.userInterface.css(c + 'AllDenied', 'opacity', '0.4');
-                tarteaucitron.userInterface.css(c + 'AllAllowed', 'opacity', '1');
+                document.getElementById(c + 'AllDenied').classList.remove('tarteaucitronIsSelected');
+                document.getElementById(c + 'AllAllowed').classList.add('tarteaucitronIsSelected');
             } else if (nbAllowed === 0 && nbPending === 0) {
-                tarteaucitron.userInterface.css(c + 'AllAllowed', 'opacity', '0.4');
-                tarteaucitron.userInterface.css(c + 'AllDenied', 'opacity', '1');
-                tarteaucitron.userInterface.css(c + 'AllDenied', 'backgroundColor', redDark);
+                document.getElementById(c + 'AllAllowed').classList.remove('tarteaucitronIsSelected');
+                document.getElementById(c + 'AllDenied').classList.add('tarteaucitronIsSelected');
             } else {
-                tarteaucitron.userInterface.css(c + 'AllAllowed', 'opacity', '0.4');
-                tarteaucitron.userInterface.css(c + 'AllDenied', 'opacity', '0.4');
+                document.getElementById(c + 'AllDenied').classList.remove('tarteaucitronIsSelected');
+                document.getElementById(c + 'AllAllowed').classList.remove('tarteaucitronIsSelected');
             }
 
             // close the alert if all service have been reviewed


### PR DESCRIPTION
The hardcoded colors green and red have been removed from the JS file.
The colors are now in the CSS file.
A new class tarteaucitronIsSelected is added to the main selected button ("Allow all" or "Deny all").