### PR TITLE
Fix Matomo/Piwik cookies detection 🐛

### DIFF
--- a/tarteaucitron.services.js
+++ b/tarteaucitron.services.js
@@ -2462,6 +2462,28 @@ tarteaucitron.services.matomo = {
         }]);
 
         tarteaucitron.addScript(tarteaucitron.user.matomoHost + 'piwik.js', '', '', true, 'defer', true);
+
+        // waiting for piwik to be ready to check first party cookies
+        var interval = setInterval(function() {
+            if (typeof Piwik === 'undefined') return
+
+            clearInterval(interval)
+
+            // make piwik/matomo cookie accessible by getting tracker
+            Piwik.getTracker();
+
+            // looping throught cookies
+            var theCookies = document.cookie.split(';');
+            for (var i = 1 ; i <= theCookies.length; i++) {
+                var cookie = theCookies[i-1].split('=');
+                var cookieName = cookie[0].trim();
+
+                // if cookie starts like a piwik one, register it
+                if (cookieName.indexOf('_pk_') === 0) {
+                    tarteaucitron.services.matomo.cookies.push(cookieName);
+                }
+            }
+        }, 100)
     }
 };
 


### PR DESCRIPTION
Fix #259 

Les cookies Piwik contiennent un domainHash, ce qui provoque la non détection par tarteaucitron de ces cookies. En récupérant la liste des cookies actuellement déposés par Piwik, on peut les compter correctement.