### PR TITLE
Prevent error for navigator without language

### DIFF
--- a/tarteaucitron.js
+++ b/tarteaucitron.js
@@ -1242,7 +1242,7 @@ var tarteaucitron = {
             defaultLanguage = 'en',
             lang = navigator.language || navigator.browserLanguage ||
                 navigator.systemLanguage || navigator.userLang || null,
-            userLanguage = lang.substr(0, 2);
+            userLanguage = lang ? lang.substr(0, 2) : null;
 
         if (tarteaucitronForceLanguage !== '') {
             if (availableLanguages.indexOf(tarteaucitronForceLanguage) !== -1) {
@@ -1261,7 +1261,7 @@ var tarteaucitron = {
 
         var lang = navigator.language || navigator.browserLanguage ||
                 navigator.systemLanguage || navigator.userLang || null,
-            userLanguage = lang.substr(0, 2);
+            userLanguage = lang ? lang.substr(0, 2) : null;
 
         if (userLanguage === 'fr') {
             return 'fr_FR';


### PR DESCRIPTION
get a user with navigator without any of those variables:
navigator.language || navigator.browserLanguage || navigator.systemLanguage || navigator.userLang
So lang.substr(0, 2) throw and error because lang is null