### PR TITLE
Don't scroll to top of page when closing popin

### DIFF
--- a/tarteaucitron.js
+++ b/tarteaucitron.js
@@ -767,7 +767,11 @@ var tarteaucitron = {
             "use strict";
 
             if (document.location.hash === tarteaucitron.hashtag) {
-                document.location.hash = '';
+                if (window.history) {
+                    window.history.replaceState('', document.title, window.location.pathname + window.location.search);
+                } else {
+                    document.location.hash = '';
+                }
             }
             tarteaucitron.userInterface.css('tarteaucitron', 'display', 'none');
             tarteaucitron.userInterface.css('tarteaucitronCookiesListContainer', 'display', 'none');


### PR DESCRIPTION
Hello,

Currently, when closing the tarteaucitron, the browser scrolls to the top of the page (because it sets the hash to `#`).
This pull request uses the history API when available to remove the hash without scrolling.