### PR TITLE
add capability of sending event when service loaded

### DIFF
--- a/tarteaucitron.js
+++ b/tarteaucitron.js
@@ -1404,6 +1404,12 @@ var tarteaucitron = {
             document.getElementsByTagName('head')[0].appendChild(script);
         }
     },
+    "sendEvent" : function(event_key) {
+        if(event_key !== undefined) {
+            var event = new Event(event_key);
+            document.dispatchEvent(event);
+        }
+    },
     "makeAsync": {
         "antiGhost": 0,
         "buffer": '',

--- a/tarteaucitron.services.js
+++ b/tarteaucitron.services.js
@@ -54,6 +54,7 @@ tarteaucitron.services.addthis = {
         }
         tarteaucitron.fallback(['addthis_sharing_toolbox'], '');
         tarteaucitron.addScript('//s7.addthis.com/js/300/addthis_widget.js#pubid=' + tarteaucitron.user.addthisPubId);
+        tarteaucitron.sendEvent('addthis_loaded');
     },
     "fallback": function () {
         "use strict";
@@ -79,6 +80,7 @@ tarteaucitron.services.addtoanyfeed = {
         window.a2a_config = window.a2a_config || {};
         window.a2a_config.linkurl = tarteaucitron.user.addtoanyfeedUri;
         tarteaucitron.addScript('//static.addtoany.com/menu/feed.js');
+        tarteaucitron.sendEvent('addtoanyfeed_loaded');
     },
     "fallback": function () {
         "use strict";
@@ -98,6 +100,7 @@ tarteaucitron.services.addtoanyshare = {
         "use strict";
         tarteaucitron.fallback(['tac_addtoanyshare'], '');
         tarteaucitron.addScript('//static.addtoany.com/menu/page.js');
+        tarteaucitron.sendEvent('addtoanyshare_loaded');
     },
     "fallback": function () {
         "use strict";
@@ -1266,6 +1269,7 @@ tarteaucitron.services.googletagmanager = {
             event: 'gtm.js'
         });
         tarteaucitron.addScript('//www.googletagmanager.com/gtm.js?id=' + tarteaucitron.user.googletagmanagerId);
+        tarteaucitron.sendEvent('gtm_loaded');
     }
 };
 


### PR DESCRIPTION
Add a new method "sendEvent" to tarteaucitron object which can send a event with a specific key
`    "sendEvent" : function(event_key) {
        if(event_key !== undefined) {
            var event = new Event(event_key);
            document.dispatchEvent(event);
        }
    },
`
This method can be used to informe third party devs when the service is available.

[French / Français]

J'ai ajouté une méthode "sendEvent" à la classe Tarteaucitron qui peut envoyer un Event avec un clef précise.
C'est une demande "régulière" dans les issues, de pouvoir être informé de "quand" un service est disponible pour pouvoir l'activer (GTM / AddThis  / AddtoAny, pour ceux où j'ai activé le sendEvent).
Cet événement va permettre au développeur de savoir quand effectuer les actions nécessaire / déclencher son code.

Merci
