### PR TITLE
convert multiplegtagUa into a string

### DIFF
--- a/tarteaucitron.services.js
+++ b/tarteaucitron.services.js
@@ -2601,7 +2601,7 @@ tarteaucitron.services.multiplegtag = {
         var cookies = ['_ga', '_gat', '_gid', '__utma', '__utmb', '__utmc', '__utmt', '__utmz'];
 
         if (tarteaucitron.user.multiplegtagUa !== undefined) {
-            tarteaucitron.user.multiplegtagUa.forEach(function(ua) {
+            tarteaucitron.user.multiplegtagUa.split(',').forEach(function(ua) {
                 cookies.push('_gat_gtag_' + ua.replace(/-/g, '_'));
             });
         }

--- a/tarteaucitron.services.js
+++ b/tarteaucitron.services.js
@@ -2612,7 +2612,7 @@ tarteaucitron.services.multiplegtag = {
         "use strict";
         window.dataLayer = window.dataLayer || [];
 
-        tarteaucitron.user.multiplegtagUa.forEach(function(ua) {
+        tarteaucitron.user.multiplegtagUa.split(',').forEach(function(ua) {
 
             tarteaucitron.addScript('https://www.googletagmanager.com/gtag/js?id=' + ua, '', function () {
                 window.gtag = function gtag(){dataLayer.push(arguments);}


### PR DESCRIPTION
Defining multiplegtagUa as a string.
Prioritizing string because it's:
- Any user fall in love with string.
non-developer users know what string is all about.
- Beginners dislike array.
new developer struggle with JavaScript Array.
- Integrate easly with CMS.
Array require special code, if used as customizable field.

The string will be splited into an array of strings using the separator.