### PR TITLE
Don't use the same class for the disclaimer and tooltips

### DIFF
--- a/tarteaucitron.js
+++ b/tarteaucitron.js
@@ -300,7 +300,7 @@ var tarteaucitron = {
                 html += '   <div id="tarteaucitronServices">';
                 html += '      <div class="tarteaucitronLine tarteaucitronMainLine" id="tarteaucitronMainLineOffset">';
                 html += '         <span class="tarteaucitronH1" role="heading" aria-level="1" id="dialogTitle">'+ tarteaucitron.lang.title + '</span>';
-                html += '         <div id="tarteaucitronInfo" class="tarteaucitronInfoBox">';
+                html += '         <div id="tarteaucitronInfo">';
                 html += '         ' + tarteaucitron.lang.disclaimer;
                 if (tarteaucitron.parameters.privacyUrl !== "") {
                     html += '   <br/><br/>';


### PR DESCRIPTION
Using the same class causes [this code](https://github.com/AmauriC/tarteaucitron.js/blob/da7272f60d54ee600779d3c0e1c22a23d46f4a61/tarteaucitron.js#L867) to add `display: none` to the disclaimer (`#tarteaucitronInfo`) if you close the pop-in, then open it again.

With the default CSS, it is not an issue because the disclaimer also has `display: block !important;`.
However, we using custom CSS, it can cause a strange behaviour where the disclaimer disapears when you reopen the pop-in.

Also, maybe I missed something but it does not look like the class actually does anything useful here.