### PR TITLE
🐛 Dispatch an event when a service is accepted

### DIFF
--- a/tarteaucitron.js
+++ b/tarteaucitron.js
@@ -748,6 +748,7 @@ var tarteaucitron = {
                     tarteaucitron.pro('!' + key + '=engage');
 
                     tarteaucitron.launch[key] = true;
+                    tarteaucitron.sendEvent(key + '_loaded');
                     tarteaucitron.services[key].js();
                 }
             }


### PR DESCRIPTION
PR #363 introduced an event to detect when a service is accepted.
This is only dispatched when the page is loaded with the service
already accepted.

This commit ensures its also dispatched when the user click the
Allow button in the service engagement placeholder.