### PR TITLE
Danish support and minor grammar error for English

### DIFF
--- a/lang/tarteaucitron.da.js
+++ b/lang/tarteaucitron.da.js
@@ -1,0 +1,77 @@
+/*global tarteaucitron */
+tarteaucitron.lang = {
+    "middleBarHead": "☝ 🍪",
+    "adblock": "Hej! Dette sted er gennemsigtigt og giver dig mulighed for at vælge de tredjeparts tjenester, du vil tillade.",
+    "adblock_call": "Deaktiver venligst din adblocker for at begynde tilpasningen.",
+    "reload": "Opdater siden",
+
+    "alertBigScroll": "Ved at fortsætte med at scrolle,",
+    "alertBigClick": "Hvis du fortsætter med at bruge dette websted,",
+    "alertBig": "tillader du alle tredjeparts tjenester",
+
+    "alertBigPrivacy": "Dette websted bruger cookies og giver dig kontrol over, hvad du vil aktivere",
+    "alertSmall": "Administrer tjenester",
+    "personalize": "Tilpas",
+    "acceptAll": "OK, accepter alle",
+    "close": "Luk",
+
+    "privacyUrl": "Fortrolighedspolitik",
+
+    "all": "Præference for alle tjenester",
+
+    "info": "Beskyttelse af dit privatliv",
+    "disclaimer": "Ved at tillade disse tredjeparts tjenester accepterer du deres cookies og brugen af sporingsteknologier, der er nødvendige for, at de fungerer korrekt.",
+    "allow": "Tillad",
+    "deny": "Afvis ",
+    "noCookie": "Denne service bruger ikke cookies",
+    "useCookie": "Denne service kan installere",
+    "useCookieCurrent": "Denne service er installeret",
+    "useNoCookie": "Denne service har ikke installeret nogen cookie.",
+    "more": "Læs mere",
+    "source": "Se det officielle websted",
+    "credit": "Cookies manager af tarteaucitron.js",
+    "noServices": "Dette websted bruger ikke nogen cookie, der kræver dit samtykke.",
+
+    "toggleInfoBox": "Vis / skjul informationer om opbevaring af cookies",
+    "title": "CCookie-styringspanel",
+    "cookieDetail": "Cookie detaljer for",
+    "ourSite": "på vores side",
+    "newWindow": "(nyt vindue)",
+    "allowAll": "Tillad alle cookies",
+    "denyAll": "Afvis alle cookies",
+
+    "fallback": "er deaktiveret.",
+
+    "ads": {
+        "title": "Annonceringsnetværk",
+        "details": "Annoncenetværk kan generere indtægter ved at sælge annonceplads på webstedet."
+    },
+    "analytic": {
+        "title": "Måling af målgruppen",
+        "details": "Målingstjenesterne bruges til at generere nyttig statistisk til at forbedre webstedet."
+    },
+    "social": {
+        "title": "Sociale netværk",
+        "details": "Sociale netværk kan forbedre anvendeligheden af webstedet og hjælpe med at markedsføre det via aktierne."
+    },
+    "video": {
+        "title": "Videoer",
+        "details": "Videodelingstjenester hjælper med at tilføje rige medier på webstedet og øger dets synlighed."
+    },
+    "comment": {
+        "title": "Kommentarer",
+        "details": "Kommentarledere letter arkiveringen af kommentarer og bekæmper spam."
+    },
+    "support": {
+        "title": "Support",
+        "details": "Supporttjenester giver dig mulighed for at komme i kontakt med webstedsteamet og hjælpe med at forbedre det."
+    },
+    "api": {
+        "title": "APIer,
+        "details": "AAPI'er bruges til at indlæse scripts: geolokalisation, søgemaskiner, oversættelser, ..."
+    },
+    "other": {
+        "title": "Andet",
+        "details": "Tjenester til visning af webindhold."
+    }
+};

--- a/lang/tarteaucitron.en.js
+++ b/lang/tarteaucitron.en.js
@@ -1,7 +1,7 @@
 /*global tarteaucitron */
 tarteaucitron.lang = {
     "middleBarHead": "☝ 🍪",
-    "adblock": "Hello! This site is transparent and lets you chose the 3rd party services you want to allow.",
+    "adblock": "Hello! This site is transparent and lets you choose the 3rd party services you want to allow.",
     "adblock_call": "Please disable your adblocker to start customizing.",
     "reload": "Refresh the page",
     

--- a/tarteaucitron.js
+++ b/tarteaucitron.js
@@ -1361,7 +1361,7 @@ var tarteaucitron = {
     "getLanguage": function () {
         "use strict";
 
-        var availableLanguages = 'cs,de,en,es,fr,it,nl,pl,pt,ru,el,ro,bg,ja,cn',
+        var availableLanguages = 'cs,de,en,es,fr,it,nl,pl,pt,ru,el,ro,bg,ja,cn,da',
             defaultLanguage = 'en';
 
         if (tarteaucitronForceLanguage !== '') {


### PR DESCRIPTION
- Support for Danish
- Fixed minor grammatical error of the word "Chose" and used "Choose" instead to keep it in present tense