### PR TITLE
fix(js): select the relevant script to define the correct path for file inclusion

### DIFF
--- a/tarteaucitron.js
+++ b/tarteaucitron.js
@@ -1,8 +1,19 @@
 /*jslint browser: true, evil: true */
 
-// define correct path for files inclusion
 var scripts = document.getElementsByTagName('script'),
-    path = scripts[scripts.length - 1].src.split('?')[0],
+    thisScript = null;
+for (var i = 0, il = scripts.length; i < il; ++i) {
+    if ( scripts[i].getAttribute('src').indexOf('tarteaucitron.js') >= 0) {
+        // should always find this script
+        thisScript = scripts[i];
+        break;
+    }
+    // should never happen
+    throw new Error("Error: tarteaucitron.js script not found");
+}
+
+// define correct path for files inclusion
+var path = thisScript.src.split('?')[0],
     tarteaucitronForceCDN = (tarteaucitronForceCDN === undefined) ? '' : tarteaucitronForceCDN,
     cdn = (tarteaucitronForceCDN === '') ? path.split('/').slice(0, -1).join('/') + '/' : tarteaucitronForceCDN,
     alreadyLaunch = (alreadyLaunch === undefined) ? 0 : alreadyLaunch,

--- a/tarteaucitron.js
+++ b/tarteaucitron.js
@@ -3,7 +3,7 @@
 var scripts = document.getElementsByTagName('script'),
     thisScript = null;
 for (var i = 0, il = scripts.length; i < il; ++i) {
-    if ( scripts[i].getAttribute('src').indexOf('tarteaucitron.js') >= 0) {
+    if ( scripts[i].getAttribute('src').indexOf('tarteaucitron') >= 0) {
         // should always find this script
         thisScript = scripts[i];
         break;


### PR DESCRIPTION
See https://stackoverflow.com/a/22745553/5487370

My case :
1) I'm using Brave browser which includes a script for "dapp detection".
See https://github.com/brave/brave-core/blob/master/components/brave_extension/extension/brave_extension/content_dapps.ts
"We need this script inserted as early as possible even before the load"
(More info about their BAT program : https://basicattentiontoken.org/)

2) My app is running  on Nuxt.js. I include tarteaucitron code inside app.html, just under `<head>` :
```
<html {{ HTML_ATTRS }}>

  <head {{ HEAD_ATTRS }}>
    <script type="text/javascript" src="/tarteaucitronjs/tarteaucitron.js"></script>
...
```
and at the end of the body :
```
...
<body {{ BODY_ATTRS }}>
    {{ APP }}
    <script type="text/javascript">
      // Google Tag Manager
      tarteaucitron.user.googletagmanagerId = 'GTM-XXXXXXXX';
      (tarteaucitron.job = tarteaucitron.job || []).push('googletagmanager');
    </script>
  </body>
```

This commit makes tarteaucitron work on Brave, but probably fixes other use cases where other scripts are loaded on the page

Could possibly help for https://github.com/AmauriC/tarteaucitron.js/issues/253