### PR TITLE
🐛 Fix inconsistent buttons height

### DIFF
--- a/css/tarteaucitron.css
+++ b/css/tarteaucitron.css
@@ -302,9 +302,9 @@ div#tarteaucitronServices {
     box-sizing: border-box;
 }
 
-#tarteaucitronAlertSmall #tarteaucitronCookiesListContainer #tarteaucitronCookiesList .tarteaucitronTitle, 
-#tarteaucitron #tarteaucitronServices .tarteaucitronTitle button, 
-#tarteaucitron #tarteaucitronInfo, 
+#tarteaucitronAlertSmall #tarteaucitronCookiesListContainer #tarteaucitronCookiesList .tarteaucitronTitle,
+#tarteaucitron #tarteaucitronServices .tarteaucitronTitle button,
+#tarteaucitron #tarteaucitronInfo,
 #tarteaucitron #tarteaucitronServices .tarteaucitronDetails {
     color: #fff;
     display: inline-block;
@@ -520,6 +520,7 @@ div#tarteaucitronServices {
     cursor: pointer;
     display: inline-block;
     font-size: 16px!important;
+    line-height: 1.2;
     padding: 5px 10px;
     text-decoration: none;
     margin-left: 7px;


### PR DESCRIPTION
Some buttons (ie. "OK, accept all", "Deny all cookies") use several fonts (because of the checkmark and cross symbols), which messes up default line-heights. Setting one fixes this.