### PR TITLE
useExternalJs should only apply to internal scripts

### DIFF
--- a/tarteaucitron.js
+++ b/tarteaucitron.js
@@ -255,12 +255,12 @@ var tarteaucitron = {
             document.getElementsByTagName('head')[0].appendChild(linkElement);
         }
         // Step 2: load language and services
-        tarteaucitron.addScript(pathToLang, '', function () {
+        tarteaucitron.addInternalScript(pathToLang, '', function () {
 
           if(tarteaucitronCustomText !== ''){
             tarteaucitron.lang = tarteaucitron.AddOrUpdate(tarteaucitron.lang, tarteaucitronCustomText);
           }
-            tarteaucitron.addScript(pathToServices, '', function () {
+            tarteaucitron.addInternalScript(pathToServices, '', function () {
 
 
                 // css for new middle bar
@@ -427,7 +427,7 @@ var tarteaucitron = {
                     html += '</div>';
                 }
 
-                tarteaucitron.addScript(tarteaucitron.cdn + 'advertising.js?v=' + tarteaucitron.version, '', function () {
+                tarteaucitron.addInternalScript(tarteaucitron.cdn + 'advertising.js?v=' + tarteaucitron.version, '', function () {
                     if (tarteaucitronNoAdBlocker === true || tarteaucitron.parameters.adblocker === false) {
 
                         // create a wrapper container at the same level than tarteaucitron so we can add an aria-hidden when tarteaucitron is opened
@@ -497,7 +497,7 @@ var tarteaucitron = {
                         tarteaucitron.cookie.number();
                         setInterval(tarteaucitron.cookie.number, 60000);
                     }
-                }, tarteaucitron.parameters.adblocker, null, null, true);
+                }, tarteaucitron.parameters.adblocker);
 
                 if (tarteaucitron.parameters.adblocker === true) {
                     setTimeout(function () {
@@ -519,8 +519,8 @@ var tarteaucitron = {
                         }
                     }, 1500);
                 }
-            }, null, null, null, true);
-        }, null, null, null, true);
+            });
+        });
 
         if(tarteaucitron.events.load) {
             tarteaucitron.events.load();
@@ -1435,6 +1435,9 @@ var tarteaucitron = {
             }
         }
     },
+    "addInternalScript": function (url, id, callback, execute, attrName, attrVal) {
+        tarteaucitron.addScript(url, id, callback, execute, attrName, attrVal, true);
+    },
     "makeAsync": {
         "antiGhost": 0,
         "buffer": '',
@@ -1464,13 +1467,13 @@ var tarteaucitron = {
                 return;
             }
             tarteaucitron.makeAsync.antiGhost += 1;
-            tarteaucitron.addScript(url, '', function () {
+            tarteaucitron.addInternalScript(url, '', function () {
                 if (document.getElementById(id) !== null) {
                     document.getElementById(id).innerHTML += "<span style='display:none'>&nbsp;</span>" + tarteaucitron.makeAsync.buffer;
                     tarteaucitron.makeAsync.buffer = '';
                     tarteaucitron.makeAsync.execJS(id);
                 }
-            }, null, null, null, true);
+            });
         },
         "execJS": function (id) {
             /* not strict because third party scripts may have errors */

--- a/tarteaucitron.js
+++ b/tarteaucitron.js
@@ -497,7 +497,7 @@ var tarteaucitron = {
                         tarteaucitron.cookie.number();
                         setInterval(tarteaucitron.cookie.number, 60000);
                     }
-                }, tarteaucitron.parameters.adblocker);
+                }, tarteaucitron.parameters.adblocker, null, null, true);
 
                 if (tarteaucitron.parameters.adblocker === true) {
                     setTimeout(function () {
@@ -519,8 +519,8 @@ var tarteaucitron = {
                         }
                     }, 1500);
                 }
-            });
-        });
+            }, null, null, null, true);
+        }, null, null, null, true);
 
         if(tarteaucitron.events.load) {
             tarteaucitron.events.load();
@@ -1396,7 +1396,7 @@ var tarteaucitron = {
             return 'en_US';
         }
     },
-    "addScript": function (url, id, callback, execute, attrName, attrVal) {
+    "addScript": function (url, id, callback, execute, attrName, attrVal, internal) {
         "use strict";
         var script,
             done = false;
@@ -1430,7 +1430,7 @@ var tarteaucitron = {
                 }
             }
 
-            if ( !tarteaucitron.parameters.useExternalJs ) {
+            if ( !tarteaucitron.parameters.useExternalJs || !internal ) {
                 document.getElementsByTagName('head')[0].appendChild(script);
             }
         }
@@ -1470,7 +1470,7 @@ var tarteaucitron = {
                     tarteaucitron.makeAsync.buffer = '';
                     tarteaucitron.makeAsync.execJS(id);
                 }
-            });
+            }, null, null, null, true);
         },
         "execJS": function (id) {
             /* not strict because third party scripts may have errors */

--- a/tarteaucitron.js
+++ b/tarteaucitron.js
@@ -1396,7 +1396,7 @@ var tarteaucitron = {
             return 'en_US';
         }
     },
-    "addScript": function (url, id, callback, execute, attrName, attrVal, internal) {
+    "addScript": function (url, id, callback, execute, attrName, attrVal, internal = false) {
         "use strict";
         var script,
             done = false;


### PR DESCRIPTION
This is a refactor of #425 with less `null`.

It adds a way to differentiate between external and internal script so that `useExternalJs` only applies to internal scripts (and does not break services).