### PR TITLE
Check localStorage for keys too

### DIFF
--- a/tarteaucitron.js
+++ b/tarteaucitron.js
@@ -1272,7 +1272,7 @@ var tarteaucitron = {
                 html += tarteaucitron.lang.useNoCookie;
             } else if (status >= 0) {
                 for (i = 0; i < nb; i += 1) {
-                    if (document.cookie.indexOf(arr[i] + '=') !== -1) {
+                    if (document.cookie.indexOf(arr[i] + '=') !== -1 || localStorage.getItem(arr[i]) !== null) {
                         nbCurrent += 1;
                         if (tarteaucitron.cookie.owner[arr[i]] === undefined) {
                             tarteaucitron.cookie.owner[arr[i]] = [];


### PR DESCRIPTION
If a script uses the localStorage and not Cookies, the checkCount() method doesn't work.
So we should also check the localStorage if a variable with the given key exists.