### PR TITLE
Fix padding css

### DIFF
--- a/css/tarteaucitron.css
+++ b/css/tarteaucitron.css
@@ -492,7 +492,7 @@ div#tarteaucitronServices {
     box-sizing: content-box;
     z-index: 2147483645;
     text-align: center;
-    padding: 10px;
+    padding: 10px 0 10px 0;
     margin: auto;
     width: 100%;
 }


### PR DESCRIPTION
Fix small problem with padding on  #tarteaucitronAlertBig because the text was larger than the device size (on phone)