### PR TITLE
Don't show the middle banner of you are on the "moreLink" page.

### DIFF
--- a/tarteaucitron.js
+++ b/tarteaucitron.js
@@ -219,8 +219,8 @@ var tarteaucitron = {
             },
             params = tarteaucitron.parameters;
 
-        // Don't show the middle bar if we are on the privacy policy page
-        if (window.location.href == tarteaucitron.parameters.privacyUrl && tarteaucitron.parameters.orientation == "middle") {
+        // Don't show the middle bar if we are on the privacy policy or more page
+        if (((tarteaucitron.parameters.readmoreLink !== undefined && window.location.href == tarteaucitron.parameters.readmoreLink) || window.location.href == tarteaucitron.parameters.privacyUrl) && tarteaucitron.parameters.orientation == "middle") {
             tarteaucitron.parameters.orientation = "bottom";
         }
 


### PR DESCRIPTION
On my website, the moreLink parameter points to the same host so it still displays the banner on middle, and therefore the user can't read this page until he has set the cookie parameters.

The patch it to overcomes this and thus, the middle banner will not be shown on both more and privacy pages.