### PR TITLE
Cookie secure - Information Disclosure

### DIFF
--- a/tarteaucitron.js
+++ b/tarteaucitron.js
@@ -1227,10 +1227,11 @@ var tarteaucitron = {
                 regex = new RegExp("!" + key + "=(wait|true|false)", "g"),
                 cookie = tarteaucitron.cookie.read().replace(regex, ""),
                 value = tarteaucitron.parameters.cookieName + '=' + cookie + '!' + key + '=' + status,
-                domain = (tarteaucitron.parameters.cookieDomain !== undefined && tarteaucitron.parameters.cookieDomain !== '') ? 'domain=' + tarteaucitron.parameters.cookieDomain + ';' : '';
+                domain = (tarteaucitron.parameters.cookieDomain !== undefined && tarteaucitron.parameters.cookieDomain !== '') ? '; domain=' + tarteaucitron.parameters.cookieDomain : '';
+                secure = location.protocol === 'https:' ? '; Secure' : '';
 
             d.setTime(expireTime);
-            document.cookie = value + '; expires=' + d.toGMTString() + '; path=/;' + domain;
+            document.cookie = value + '; expires=' + d.toGMTString() + '; path=/' + domain + secure + '; samesite=lax';
         },
         "read": function () {
             "use strict";


### PR DESCRIPTION
Suite à des audits de sécurité sur quelques sites, nous nous sommes fait "retoqués" sur la non mise en œuvre de la propriété "`secure`" lors de la définition des cookies par tarteaucitron (_et `samesite=lax` même s'il s'agit de la valeur par défaut des navigateurs récents_).

https://tools.ietf.org/html/rfc6265#section-8.3 : 

> Servers SHOULD encrypt and sign the contents of cookies (using whatever format the server desires) when transmitting them to the user agent (even when sending the cookies over a secure channel). However, encrypting and signing cookie contents does not prevent an attacker from transplanting a cookie from one user agent to another or from replaying the cookie at a later time.

Les modifications étant limitées, je propose cette PR afin d'inclure cette déclaration pour les sites en HTTPS.

A votre écoute,