### PR TITLE
remove action on mandatory button

### DIFF
--- a/tarteaucitron.js
+++ b/tarteaucitron.js
@@ -330,7 +330,7 @@ var tarteaucitron = {
                 if (tarteaucitron.parameters.mandatory == true) {
                    html += '<li id="tarteaucitronServicesTitle_mandatory">';
                    html += '<div class="tarteaucitronTitle">';
-                   html += '   <button type="button">&nbsp; ' + tarteaucitron.lang.mandatoryTitle + '</button>';
+                   html += '   <button type="button" tabindex="-1">&nbsp; ' + tarteaucitron.lang.mandatoryTitle + '</button>';
                    html += '</div>';
                    html += '<ul id="tarteaucitronServices_mandatory">';
                    html += '<li class="tarteaucitronLine">';


### PR DESCRIPTION
Le bouton  "Mandatory cookies" ne déclenche aucune action. 
Il n'a donc pas besoin d'être focusable pour les lecteurs d'écran.