### PR TITLE
Fix buttons not working for dynamically added services

### DIFF
--- a/tarteaucitron.js
+++ b/tarteaucitron.js
@@ -715,6 +715,14 @@ var tarteaucitron = {
             tarteaucitron.userInterface.css('tarteaucitronNoServicesTitle', 'display', 'none');
 
             tarteaucitron.userInterface.order(service.type);
+
+            tarteaucitron.addClickEventToId(service.key + 'Allowed', function () {
+                tarteaucitron.userInterface.respond(this, true);
+            });
+
+            tarteaucitron.addClickEventToId(service.key + 'Denied', function () {
+                tarteaucitron.userInterface.respond(this, false);
+            });
         }
 
         tarteaucitron.pro('!' + service.key + '=' + isAllowed);


### PR DESCRIPTION
If I add a service after tarteaucitron is fully initialized, the new Allow/Deny buttons won't work because they don't have a listener.

Example: I have tarteaucitron configured with only Google Analytics. Then, I add YouTube by running in Chrome's dev console:
`(tarteaucitron.job = tarteaucitron.job || []).push('youtube');`
In this case, I can accept all/deny all, but I can't accept/deny just YouTube.

![image](https://user-images.githubusercontent.com/16822473/98291630-b9ae2b00-1fab-11eb-8f94-9979af7b517a.png)


I think the problem appeared in this commit: https://github.com/AmauriC/tarteaucitron.js/commit/d481f0e911c38d4f3bf8c6ad736275cbf15bd537
