### PR TITLE
Fix use of the non standard property “zoom”

### DIFF
--- a/css/tarteaucitron.css
+++ b/css/tarteaucitron.css
@@ -140,10 +140,6 @@ div#tarteaucitronServices {
 /***
  * Common value
  */
-#tarteaucitron * {
-    zoom: 1;
-}
-
 #tarteaucitronRoot div#tarteaucitron {
     left: 0;
     right: 0;


### PR DESCRIPTION
To fix Firefox warning:

EN: This page uses the non standard property “zoom”. Consider using calc() in the relevant property values, or using “transform” along with “transform-origin: 0 0”.

FR: Cette page utilise la propriété non standard « zoom ». Envisagez d’utiliser calc() dans les valeurs des propriétés pertinentes ou utilisez « transform » avec « transform-origin: 0 0 ».