### PR TITLE
Callback called too soon for external scripts

### DIFF
--- a/tarteaucitron.js
+++ b/tarteaucitron.js
@@ -1598,7 +1598,7 @@ var tarteaucitron = {
             }
 
             if (typeof callback === 'function') {
-                if ( !tarteaucitron.parameters.useExternalJs ) {
+                if ( !tarteaucitron.parameters.useExternalJs || !internal ) {
                     script.onreadystatechange = script.onload = function () {
                         var state = script.readyState;
                         if (!done && (!state || /loaded|complete/.test(state))) {


### PR DESCRIPTION
This is a followup to #440.

When useExternalJs is enabled, the callback is called immediately for internal scripts because we don't have an onreadystatechange event (because the script is not inserted by tarteaucitron).
However, for external scripts, we do want to wait for the event to be triggered.