### PR TITLE
Replace "ce" by "ceux" 

### DIFF
--- a/lang/tarteaucitron.fr.js
+++ b/lang/tarteaucitron.fr.js
@@ -10,7 +10,7 @@ tarteaucitron.lang = {
     "alertBigClick": "En poursuivant votre navigation,",
     "alertBig": "vous acceptez l'utilisation de services tiers pouvant installer des cookies",
     
-    "alertBigPrivacy": "Ce site utilise des cookies et vous donne le contrôle sur ce que vous souhaitez activer",
+    "alertBigPrivacy": "Ce site utilise des cookies et vous donne le contrôle sur ceux que vous souhaitez activer",
     "alertSmall": "Gestion des services",
     "acceptAll": "OK, tout accepter",
     "personalize": "Personnaliser",


### PR DESCRIPTION
Proposition de correction : 
remplacement de **ce** par **ceux**
Contexte d'origine :
Ce site utilise des cookies et vous donne le contrôle sur **ce** que vous souhaitez activer
Contexte modifier :
Ce site utilise **des cookies** et vous donne le contrôle sur **ceux** que vous souhaitez activer

Si le "ce" du contexte d'origine désigne "les cookies" il faut le remplacer par "ceux"

Cordialement