### PR TITLE
Add function to trigger all jobs after ajax call

### DIFF
--- a/tarteaucitron.js
+++ b/tarteaucitron.js
@@ -1819,5 +1819,14 @@ var tarteaucitron = {
                 e.attachEvent("onclick", func);
             }
         }
+    },
+    "triggerJobsAfterAjaxCall": function() {
+        tarteaucitron.job.forEach(function(e) { tarteaucitron.job.push(e) });
+        var allowBtns = document.getElementsByClassName("tarteaucitronAllow");
+        for (i = 0; i < allowBtns.length; i++) {
+            tarteaucitron.addClickEventToElement(allowBtns[i], function () {
+                tarteaucitron.userInterface.respond(this, true);
+            });
+        }
     }
 };


### PR DESCRIPTION
When you add a `<div>` tag through an ajax call, and add for example : 
`<div class="youtube_player" videoID="lc2n58vzhz8" width="100%" height="300" theme="light" rel="0" controls="1" showinfo="1" autoplay="0" mute="0"></div>`
 
It won't trigger all the tarteaucitron.js logic (checking the cookie + filling the `div `with the `iframe` / asking for manual consent for this specific source)

This PR adds a function to trigger all jobs after the ajax call that write the `<div>`

You have simply to call `tarteaucitron.triggerJobsAfterAjaxCall();` after writing the `div` and the browser fire again all the jobs + fix the click on the allow button if cookies for this source are not allowed.