### PR TITLE
Allow embed of Dailymotion playlists

### DIFF
--- a/tarteaucitron.services.js
+++ b/tarteaucitron.services.js
@@ -637,6 +637,7 @@ tarteaucitron.services.dailymotion = {
                 video_height = x.getAttribute("height"),
                 frame_height = 'height=',
                 video_frame,
+                embed_type = x.getAttribute("embedType"),
                 params = 'info=' + x.getAttribute("showinfo") + '&autoPlay=' + x.getAttribute("autoplay");
 
             if (video_id === undefined) {
@@ -652,7 +653,10 @@ tarteaucitron.services.dailymotion = {
             } else {
                 frame_height += '"" ';
             }
-            video_frame = '<iframe src="//www.dailymotion.com/embed/video/' + video_id + '?' + params + '" ' + frame_width + frame_height + ' frameborder="0" allowfullscreen></iframe>';
+            if (embed_type === undefined || !['video', 'playlist'].includes(embed_type) ) {
+                embed_type = "video";
+            }
+            video_frame = '<iframe src="//www.dailymotion.com/embed/' + embed_type + '/' + video_id + '?' + params + '" ' + frame_width + frame_height + ' frameborder="0" allowfullscreen></iframe>';
             return video_frame;
         });
     },


### PR DESCRIPTION
Current embed only allow to embed video but not playlist.
We add a setting `embedType `which can be set to **video** or **playlist**

And we keep backward compatibility with current embed code by setting this `embedType `to **video** by default.

**Dailymotion Video :** 
`<div class="dailymotion_player" videoID="x6xzzni" width="100%" height="300" showinfo="1" autoplay="0"></div>
`
or
`<div class="dailymotion_player" videoID="x6xzzni" embedType="video" width="100%" height="300" showinfo="1" autoplay="0"></div>
`

**Dailymotion Playlist :**
`<div class="dailymotion_player" videoID="x5vcbn" embedType="playlist" width="100%" height="300" showinfo="1" autoplay="0"></div>`
