### PR TITLE
Use jsdelivr minified files when delivered from jsdelivr CDN

### DIFF
--- a/tarteaucitron.js
+++ b/tarteaucitron.js
@@ -196,8 +196,9 @@ var tarteaucitron = {
         "use strict";
         var cdn = tarteaucitron.cdn,
             language = tarteaucitron.getLanguage(),
-            pathToLang = cdn + 'lang/tarteaucitron.' + language + '.js?v=' + tarteaucitron.version,
-            pathToServices = cdn + 'tarteaucitron.services.js?v=' + tarteaucitron.version,
+            useJSDelivrMinifiedJS = cdn.includes("cdn.jsdelivr.net"),
+            pathToLang = cdn + 'lang/tarteaucitron.' + language + (useJSDelivrMinifiedJS ? '.min' : '') + '.js?v=' + tarteaucitron.version,
+            pathToServices = cdn + 'tarteaucitron.services' + (useJSDelivrMinifiedJS ? '.min' : '') + '.js?v=' + tarteaucitron.version,
             linkElement = document.createElement('link'),
             defaults = {
                 "adblocker": false,

--- a/tarteaucitron.js
+++ b/tarteaucitron.js
@@ -254,7 +254,7 @@ var tarteaucitron = {
         if ( !tarteaucitron.parameters.useExternalCss ) {
             linkElement.rel = 'stylesheet';
             linkElement.type = 'text/css';
-            linkElement.href = cdn + 'css/tarteaucitron.css?v=' + tarteaucitron.version;
+            linkElement.href = cdn + 'css/tarteaucitron' + (useJSDelivrMinifiedJS ? '.min' : '') + '.css?v=' + tarteaucitron.version;
             document.getElementsByTagName('head')[0].appendChild(linkElement);
         }
         // Step 2: load language and services
@@ -471,7 +471,7 @@ var tarteaucitron = {
                     html += '</div>';
                 }
 
-                tarteaucitron.addInternalScript(tarteaucitron.cdn + 'advertising.js?v=' + tarteaucitron.version, '', function () {
+                tarteaucitron.addInternalScript(tarteaucitron.cdn + 'advertising' + (useJSDelivrMinifiedJS ? '.min' : '') + '.js?v=' + tarteaucitron.version, '', function () {
                     if (tarteaucitronNoAdBlocker === true || tarteaucitron.parameters.adblocker === false) {
 
                         // create a wrapper container at the same level than tarteaucitron so we can add an aria-hidden when tarteaucitron is opened


### PR DESCRIPTION
Jsdelivr offers an automatic minifier tool (_Add ".min" to any JS/CSS file to get a minified version - if one doesn't exist, we'll generate it for you. All generated files come with source maps and can be easily used during development_)

As many tarteaucitron users load scripts from jsdelivr (44 million downloads / month according to counter on the official repo https://www.jsdelivr.com/package/gh/AmauriC/tarteaucitron.js and not counting all the forks ), it will save a lot of bandwidth...

Currently:
tarteaucitron.min.js (12,7 ko) vs tarteaucitron.js (16,7 ko) : -24%
tarteaucitron.services.min.js (16,4 ko) vs tarteaucitron.services.js (20,5 ko) : -10%
css/tarteaucitron.min.css (3,9 ko) vs css/tarteaucitron.min.css (4,2 ko) : -7%

NB: I have also add it to be consistent on language files & advertising.js but it does not save weight due to added comment lines.