### PR TITLE
Integrates with Google Consent Mode #639

### DIFF
--- a/tarteaucitron.services.js
+++ b/tarteaucitron.services.js
@@ -1577,10 +1577,46 @@ tarteaucitron.services.gtag = {
         return ['_ga', '_gat', '_gid', '__utma', '__utmb', '__utmc', '__utmt', '__utmz', tagUaCookie, tagGCookie];
     })(),
     "js": function () {
+      "use strict";
+      if(typeof gtag !== 'undefined'){
+        gtag('consent', 'update', {
+          'ad_storage': 'granted',
+          'analytics_storage': 'granted'
+        });
+
+        return;
+      }
+
+      window.dataLayer = window.dataLayer || [];
+      tarteaucitron.addScript('https://www.googletagmanager.com/gtag/js?id=' + tarteaucitron.user.gtagUa, '', function () {
+          window.gtag = function gtag(){dataLayer.push(arguments);}
+
+          // Default ad_storage to 'denied'.
+          gtag('consent', 'default', {
+            'ad_storage': 'granted',
+            'analytics_storage': 'granted'
+          });
+
+          gtag('js', new Date());
+          gtag('config', tarteaucitron.user.gtagUa);
+
+          if (typeof tarteaucitron.user.gtagMore === 'function') {
+              tarteaucitron.user.gtagMore();
+          }
+      });
+    },
+    "fallback": function () {
         "use strict";
         window.dataLayer = window.dataLayer || [];
         tarteaucitron.addScript('https://www.googletagmanager.com/gtag/js?id=' + tarteaucitron.user.gtagUa, '', function () {
             window.gtag = function gtag(){dataLayer.push(arguments);}
+
+            // Default ad_storage to 'denied'.
+            gtag('consent', 'default', {
+              'ad_storage': 'denied',
+              'analytics_storage': 'denied'
+            });
+
             gtag('js', new Date());
             gtag('config', tarteaucitron.user.gtagUa);
 


### PR DESCRIPTION
Google Consent Mode is a new way for your website to measure conversions and get analytics insights while being fully GDPR compliant when using services like Google Analytics, Google Tag Manager (GTM) and Google Ads.

With the Google Consent Mode, your website is able to make all Google services run in one simple way: based on the consent of your end-users.

We made this PR as part of making `tarteaucitron.js` integrate seamlessly with Google Consent Mode.

I would like to share with you :
1. a Drupal 9 website with the current modifications [https://pr-1-djjnuwy-gelmsgg7am6ga.ovh-fr-2.platformsh.site/](https://pr-1-djjnuwy-gelmsgg7am6ga.ovh-fr-2.platformsh.site/)
2. a Google Guide on how to use the new Consent functionality [https://developers.google.com/gtagjs/devguide/consent](https://developers.google.com/gtagjs/devguide/consent)