### PR TITLE
Update Instagram integration

### DIFF
--- a/tarteaucitron.services.js
+++ b/tarteaucitron.services.js
@@ -1832,28 +1832,37 @@ tarteaucitron.services.instagram = {
     "js": function () {
         "use strict";
         tarteaucitron.fallback(['instagram_post'], function (x) {
-            var frame_title = tarteaucitron.fixSelfXSS(x.getAttribute("title") || 'Instagram iframe'),
-                post_id = x.getAttribute("postId"),
-                embed_width = x.getAttribute("width"),
-                frame_width = 'width=',
-                embed_height = x.getAttribute("height"),
-                frame_height = 'height=',
+            var post_id = x.getAttribute('postId'),
+                post_permalink = x.getAttribute('data-instgrm-permalink'),
+                embed_width = x.getAttribute('width'),
+                embed_height = x.getAttribute('height'),
+                frame_width,
+                frame_height,
                 post_frame;
+
+            if (post_permalink != null) {
+                tarteaucitron.addScript('//www.instagram.com/embed.js', 'instagram-embed');
+
+                return '';
+            }
 
             if (post_id === undefined) {
                 return "";
             }
+
             if (embed_width !== undefined) {
-                frame_width += '"' + embed_width + '" ';
+                frame_width = 'width="' + embed_width + '" ';
             } else {
-                frame_width += '"" ';
+                frame_width = '"" ';
             }
             if (embed_height !== undefined) {
-                frame_height +=  '"' + embed_height + '" ';
+                frame_height = 'height="' + embed_height + '" ';
             } else {
-                frame_height += '"" ';
+                frame_height = '"" ';
             }
-            post_frame = '<iframe title="' + frame_title + '" src="//www.instagram.com/' + post_id + '/embed" ' + frame_width + frame_height + '></iframe>';
+
+            post_frame = '<iframe title="Instagram iframe" src="//www.instagram.com/' + post_id + '/embed" ' + frame_width + frame_height + '></iframe>';
+
             return post_frame;
         });
     },

--- a/tarteaucitron.services.js
+++ b/tarteaucitron.services.js
@@ -1833,6 +1833,7 @@ tarteaucitron.services.instagram = {
         "use strict";
         tarteaucitron.fallback(['instagram_post'], function (x) {
             var frame_title = tarteaucitron.fixSelfXSS(x.getAttribute("title") || 'Instagram iframe'),
+                post_id = x.getAttribute('postId'),
                 post_permalink = x.getAttribute('data-instgrm-permalink'),
                 embed_width = x.getAttribute('width'),
                 embed_height = x.getAttribute('height'),

--- a/tarteaucitron.services.js
+++ b/tarteaucitron.services.js
@@ -1832,7 +1832,7 @@ tarteaucitron.services.instagram = {
     "js": function () {
         "use strict";
         tarteaucitron.fallback(['instagram_post'], function (x) {
-            var post_id = x.getAttribute('postId'),
+            var frame_title = tarteaucitron.fixSelfXSS(x.getAttribute("title") || 'Instagram iframe'),
                 post_permalink = x.getAttribute('data-instgrm-permalink'),
                 embed_width = x.getAttribute('width'),
                 embed_height = x.getAttribute('height'),
@@ -1861,7 +1861,7 @@ tarteaucitron.services.instagram = {
                 frame_height = '"" ';
             }
 
-            post_frame = '<iframe title="Instagram iframe" src="//www.instagram.com/' + post_id + '/embed" ' + frame_width + frame_height + '></iframe>';
+            post_frame = '<iframe title="' + frame_title + '" src="//www.instagram.com/' + post_id + '/embed" ' + frame_width + frame_height + '></iframe>';
 
             return post_frame;
         });


### PR DESCRIPTION
The current implementation of the Instagram service seems a bit outdated.  
Also you need to set a fixed height, otherwise after authorizing the service by clicking the button inside the placeholder, the iframe does not resize automatically to the correct height.  

Currently when copying an embed from Instagram you get this kind of code sample: 
```html
<blockquote class="instagram-media" data-instgrm-permalink="https://www.instagram.com/p/{post_id}" data-instgrm-version="13"></blockquote>
<script async src="//www.instagram.com/embed.js"></script>
```

I updated the service definition so you can use the `data-instgrm-permalink` attribute with the full URL of the post instead of the ID. When using this attribute, tarteaucitron will just import the script after opt-in.

This way you only need to include the HTML part without the script and to add the `instagram_post` class.
```html
<blockquote class="instagram_post instagram-media" data-instgrm-permalink="https://www.instagram.com/p/{post_id}" data-instgrm-version="13"></blockquote>
```