### PR TITLE
[Accessibilité] Ajout d'une information textuelle sur l'état courant des services.

### DIFF
--- a/lang/tarteaucitron.bg.js
+++ b/lang/tarteaucitron.bg.js
@@ -42,6 +42,8 @@ tarteaucitron.lang = {
     "icon": "Cookies",
     
     "fallback": "е изключен.",
+    "allowed": "Позволен",
+    "disallowed": "Забранено",
 
     "ads": {
         "title": "Рекламодатели",

--- a/lang/tarteaucitron.ca.js
+++ b/lang/tarteaucitron.ca.js
@@ -42,6 +42,8 @@ tarteaucitron.lang = {
     "icon": "Cookies",
     
     "fallback": "està deshabilitat.",
+    "allowed": "Permès",
+    "disallowed": "Desautoritzat",
 
     "ads": {
         "title": "Xarxa de publicitat",

--- a/lang/tarteaucitron.cn.js
+++ b/lang/tarteaucitron.cn.js
@@ -40,6 +40,8 @@ tarteaucitron.lang = {
     "icon": "Cookies",
 
     "fallback": "已禁用。",
+    "allowed": "允许的",
+    "disallowed": "不允许的",
 
     "ads": {
         "title": "广告组",

--- a/lang/tarteaucitron.cs.js
+++ b/lang/tarteaucitron.cs.js
@@ -42,6 +42,8 @@ tarteaucitron.lang = {
     "icon": "Cookies",
     
     "fallback": "je vypnutý.",
+    "allowed": "povoleno",
+    "disallowed": "nepovoleno",
 
     "ads": {
         "title": "Reklamní síť",

--- a/lang/tarteaucitron.da.js
+++ b/lang/tarteaucitron.da.js
@@ -43,6 +43,8 @@ tarteaucitron.lang = {
     "icon": "Cookies",
 
     "fallback": "er deaktiveret.",
+    "allowed": "tilladt",
+    "disallowed": "ikke tilladt",
 
     "ads": {
         "title": "Annonceringsnetværk",

--- a/lang/tarteaucitron.de.js
+++ b/lang/tarteaucitron.de.js
@@ -42,6 +42,8 @@ tarteaucitron.lang = {
     "icon": "Cookies",
     
     "fallback": "ist deaktiviert.",
+    "allowed": "erlaubt",
+    "disallowed": "nicht erlaubt",
 
     "ads": {
         "title": "Werbenetzwerke",

--- a/lang/tarteaucitron.el.js
+++ b/lang/tarteaucitron.el.js
@@ -42,6 +42,8 @@ tarteaucitron.lang = {
     "icon": "Cookies",
     
     "fallback": "είναι απενεργοποιημένο.",
+    "allowed": "επιτρέπεται",
+    "disallowed": "απαγορεύεται",
 
     "ads": {
         "title": "Διαφημιστικό Δίκτυο",

--- a/lang/tarteaucitron.en.js
+++ b/lang/tarteaucitron.en.js
@@ -43,6 +43,8 @@ tarteaucitron.lang = {
     "icon": "Cookies",
     
     "fallback": "is disabled.",
+    "allowed": "allowed",
+    "disallowed": "disallowed",
 
     "ads": {
         "title": "Advertising network",

--- a/lang/tarteaucitron.es.js
+++ b/lang/tarteaucitron.es.js
@@ -42,6 +42,8 @@ tarteaucitron.lang = {
     "icon": "Cookies",
     
     "fallback": "está deshabilitado.",
+    "allowed": "permitido",
+    "disallowed": "rechazado",
 
     "ads": {
         "title": "Red de publicidad",

--- a/lang/tarteaucitron.fi.js
+++ b/lang/tarteaucitron.fi.js
@@ -43,6 +43,8 @@ tarteaucitron.lang = {
     "icon": "Cookies",
    
     "fallback": "hylätty.",
+    "allowed": "sallittu",
+    "disallowed": "kielletty",
 
     "ads": {
         "title": "Mainosverkosto",

--- a/lang/tarteaucitron.fr.js
+++ b/lang/tarteaucitron.fr.js
@@ -44,6 +44,8 @@ tarteaucitron.lang = {
     "icon": "Cookies",
     
     "fallback": "est désactivé.",
+    "allowed": "autorisé",
+    "disallowed": "interdit",
 
     "ads": {
         "title": "Régies publicitaires",

--- a/lang/tarteaucitron.hu.js
+++ b/lang/tarteaucitron.hu.js
@@ -43,6 +43,8 @@ tarteaucitron.lang = {
     "icon": "Cookies",
     
     "fallback": "letiltott.",
+    "allowed": "megengedett",
+    "disallowed": "nem engedélyezett",
 
     "ads": {
         "title": "Reklámhálózat",

--- a/lang/tarteaucitron.it.js
+++ b/lang/tarteaucitron.it.js
@@ -42,6 +42,8 @@ tarteaucitron.lang = {
     "icon": "Cookies",
     
     "fallback": "è disattivato",
+    "allowed": "permesso",
+    "disallowed": "non consentito",
     
     "ads": {
         "title": "Regie pubblicitarie",

--- a/lang/tarteaucitron.ja.js
+++ b/lang/tarteaucitron.ja.js
@@ -43,6 +43,8 @@ tarteaucitron.lang = {
     "icon": "Cookies",
     
     "fallback": "is disabled.",
+    "allowed": "許可",
+    "disallowed": "許可されていません",
 
     "ads": {
         "title": "Advertising network",

--- a/lang/tarteaucitron.lv.js
+++ b/lang/tarteaucitron.lv.js
@@ -43,6 +43,8 @@ tarteaucitron.lang = {
     "icon": "Cookies",
     
     "fallback": "letiltott.",
+    "allowed": "atļauts",
+    "disallowed": "nav atļauts",
 
     "ads": {
         "title": "Reklámhálózat",

--- a/lang/tarteaucitron.nl.js
+++ b/lang/tarteaucitron.nl.js
@@ -32,6 +32,8 @@ tarteaucitron.lang = {
     "credit": "Cookie manager mogelijk gemaakt door tarteaucitron.js",
     
     "fallback": "is uitgeschakeld.",
+    "allowed": "toegestaan",
+    "disallowed": "niet toegestaan",
 
     "toggleInfoBox": "Toon/verberg informatie over cookie opslag",
     "title": "Cookies beheer paneel",

--- a/lang/tarteaucitron.no.js
+++ b/lang/tarteaucitron.no.js
@@ -43,6 +43,8 @@ tarteaucitron.lang = {
     "icon": "Cookies",
 
 	"fallback" : "er skrudd av.",
+	"allowed": "tillatt",
+    "disallowed": "ikke tillatt",
 
 	"ads"      : {
 		"title"   : "Annonsenettverk",

--- a/lang/tarteaucitron.oc.js
+++ b/lang/tarteaucitron.oc.js
@@ -44,6 +44,8 @@ tarteaucitron.lang = {
     "icon": "Cookies",
     
     "fallback": "es desactivat.",
+    "allowed": "allowed",
+    "disallowed": "disallowed",
 
     "ads": {
         "title": "Regias publicitàrias",

--- a/lang/tarteaucitron.pl.js
+++ b/lang/tarteaucitron.pl.js
@@ -42,6 +42,8 @@ tarteaucitron.lang = {
     "icon": "Cookies",
     
     "fallback": "jest nieaktywna.",
+    "allowed": "dozwolony",
+    "disallowed": "niedozwolone",
 
     "ads": {
         "title": "Sieć reklamowa",

--- a/lang/tarteaucitron.pt.js
+++ b/lang/tarteaucitron.pt.js
@@ -41,6 +41,9 @@ tarteaucitron.lang = {
     "icon": "Cookies",
 
     "fallback": "está desativado.",
+    "allowed": "permitido",
+    "disallowed": "não permitido",
+    
     "ads": {
         "title": "Rede de anúncios",
         "details": "As redes de anúncios podem gerar receitas com a venda de espaço publicitário no site."

--- a/lang/tarteaucitron.ro.js
+++ b/lang/tarteaucitron.ro.js
@@ -42,6 +42,8 @@ tarteaucitron.lang = {
     "icon": "Cookies",
     
     "fallback": "este dezactivat.",
+    "allowed": "permis",
+    "disallowed": "nepermis",
 
     "ads": {
         "title": "Rețea de publicitate",

--- a/lang/tarteaucitron.ru.js
+++ b/lang/tarteaucitron.ru.js
@@ -43,6 +43,8 @@ tarteaucitron.lang = {
     
     
     "fallback": "Деактивирован.",
+    "allowed": "разрешается",
+    "disallowed": "запрещено",
 
     "ads": {
         "title": "Рекламная сеть",

--- a/lang/tarteaucitron.se.js
+++ b/lang/tarteaucitron.se.js
@@ -42,6 +42,8 @@ tarteaucitron.lang = {
     "icon": "Cookies",
 
     "fallback": "är ur funktion.",
+    "allowed": "tillåten",
+    "disallowed": "tillåtet",
 
     "ads": {
         "title": "Annonsnätverk",

--- a/lang/tarteaucitron.sk.js
+++ b/lang/tarteaucitron.sk.js
@@ -43,6 +43,8 @@ tarteaucitron.lang = {
     "icon": "Cookies",
     
     "fallback": "je zakázané.",
+    "allowed": "povolený",
+    "disallowed": "nepovolený",
 
     "ads": {
         "title": "Reklamná sieť",

--- a/lang/tarteaucitron.sv.js
+++ b/lang/tarteaucitron.sv.js
@@ -42,6 +42,8 @@ tarteaucitron.lang = {
     "icon": "Cookies",
 
     "fallback": "är ur funktion.",
+    "allowed": "dovoljeno",
+    "disallowed": "nedovoljeno",
 
     "ads": {
         "title": "Annonsnätverk",

--- a/lang/tarteaucitron.tr.js
+++ b/lang/tarteaucitron.tr.js
@@ -44,6 +44,8 @@ tarteaucitron.lang = {
     "icon": "Cookies",
     
     "fallback": "devre dışı.",
+    "allowed": "izin verildi",
+    "disallowed": "izin verilmeyen",
 
     "ads": {
         "title": "Reklam yönetimi",

--- a/lang/tarteaucitron.vi.js
+++ b/lang/tarteaucitron.vi.js
@@ -43,6 +43,8 @@ tarteaucitron.lang = {
     "icon": "Cookies",
 
     "fallback": "tắt.",
+    "allowed": "được phép",
+    "disallowed": "không được phép",
 
     "ads": {
         "title": "Mạng quảng cáo",

--- a/lang/tarteaucitron.zh.js
+++ b/lang/tarteaucitron.zh.js
@@ -40,6 +40,8 @@ tarteaucitron.lang = {
     "icon": "Cookies",
 
     "fallback": "已禁用。",
+    "allowed": "允许的",
+    "disallowed": "不允许的",
 
     "ads": {
         "title": "广告组",

--- a/tarteaucitron.js
+++ b/tarteaucitron.js
@@ -391,7 +391,7 @@ var tarteaucitron = {
                 }
 
                 if (tarteaucitron.parameters.highPrivacy && !tarteaucitron.parameters.AcceptAllCta) {
-                    html += '<div id="tarteaucitronAlertBig" class="tarteaucitronAlertBig' + orientation + '">';
+                    html += '<div tabindex="-1" id="tarteaucitronAlertBig" class="tarteaucitronAlertBig' + orientation + '">';
                     //html += '<div class="tarteaucitronAlertBigWrapper">';
                     html += '   <span id="tarteaucitronDisclaimerAlert">';
                     html += '       ' + tarteaucitron.lang.alertBigPrivacy;
@@ -411,7 +411,7 @@ var tarteaucitron = {
                     //html += '</div>';
                     html += '</div>';
                 } else {
-                    html += '<div id="tarteaucitronAlertBig" class="tarteaucitronAlertBig' + orientation + '">';
+                    html += '<div tabindex="-1" id="tarteaucitronAlertBig" class="tarteaucitronAlertBig' + orientation + '">';
                     //html += '<div class="tarteaucitronAlertBigWrapper">';
                     html += '   <span id="tarteaucitronDisclaimerAlert">';
 
@@ -595,11 +595,11 @@ var tarteaucitron = {
                     }, 1500);
                 }
                 if(tarteaucitron.parameters.closePopup === true){
-                    let element = document.getElementById('tarteaucitronAlertBig');
-                    let span = document.createElement('span')
-                    span.textContent = 'X';
-                    span.setAttribute('id', "tarteaucitronCloseCross")
-                    element.insertBefore(span, element.firstElementChild)
+                    var closeElement = document.getElementById('tarteaucitronAlertBig'),
+                    closeSpan = document.createElement('span');
+                    closeSpan.textContent = 'X';
+                    closeSpan.setAttribute('id', "tarteaucitronCloseCross");
+                    closeElement.insertBefore(closeSpan, closeElement.firstElementChild);
                 }
 
 
@@ -1247,8 +1247,8 @@ var tarteaucitron = {
             }
             //end ie compatibility
 
-            if (document.getElementById('tarteaucitronPersonalize2') !== null) {
-                document.getElementById('tarteaucitronPersonalize2').focus();
+            if (document.getElementById('tarteaucitronAlertBig') !== null) {
+                document.getElementById('tarteaucitronAlertBig').focus();
             }
 
             window.dispatchEvent(tacOpenAlertEvent);

--- a/tarteaucitron.js
+++ b/tarteaucitron.js
@@ -17,7 +17,7 @@ var scripts = document.getElementsByTagName('script'),
 
 
 var tarteaucitron = {
-    "version": 20210310,
+    "version": 20210422,
     "cdn": cdn,
     "user": {},
     "lang": {},
@@ -745,14 +745,15 @@ var tarteaucitron = {
             isDenied = (cookie.indexOf(service.key + '=false') >= 0),
             isAllowed = ((cookie.indexOf(service.key + '=true') >= 0) || (!service.needConsent && cookie.indexOf(service.key + '=false') < 0)),
             isResponded = (cookie.indexOf(service.key + '=false') >= 0 || cookie.indexOf(service.key + '=true') >= 0),
-            isDNTRequested = (navigator.doNotTrack === "1" || navigator.doNotTrack === "yes" || navigator.msDoNotTrack === "1" || window.doNotTrack === "1");
+            isDNTRequested = (navigator.doNotTrack === "1" || navigator.doNotTrack === "yes" || navigator.msDoNotTrack === "1" || window.doNotTrack === "1"),
+            currentStatus = (isAllowed) ? tarteaucitron.lang.allowed : tarteaucitron.lang.disallowed;
 
         if (tarteaucitron.added[service.key] !== true) {
             tarteaucitron.added[service.key] = true;
 
             html += '<li id="' + service.key + 'Line" class="tarteaucitronLine">';
             html += '   <div class="tarteaucitronName">';
-            html += '       <span class="tarteaucitronH3" role="heading" aria-level="3">' + service.name + '</span>';
+            html += '       <span class="tarteaucitronH3" role="heading" aria-level="3">' + service.name + ' (<span id="tacCurrentStatus' + service.key + '">'+currentStatus+'</span>)</span>';
             html += '       <span id="tacCL' + service.key + '" class="tarteaucitronListCookies"></span><br/>';
 
             if (tarteaucitron.parameters.moreInfoLink == true) {
@@ -955,6 +956,12 @@ var tarteaucitron = {
                         if (typeof tarteaucitronMagic === 'undefined' || tarteaucitronMagic.indexOf("_" + key + "_") < 0) { tarteaucitron.services[key].js(); }
                         tarteaucitron.sendEvent(key + '_loaded');
                     }
+                    var itemStatusElem = document.getElementById('tacCurrentStatus'+key);
+                    if(status == true){
+                        itemStatusElem.innerHTML = tarteaucitron.lang.allowed;
+                    }else{
+                        itemStatusElem.innerHTML = tarteaucitron.lang.disallowed;
+                    }
                     tarteaucitron.state[key] = status;
                     tarteaucitron.cookie.create(key, status);
                     tarteaucitron.userInterface.color(key, status);
@@ -989,6 +996,12 @@ var tarteaucitron = {
                     tarteaucitron.sendEvent(key + '_loaded');
                     if (typeof tarteaucitronMagic === 'undefined' || tarteaucitronMagic.indexOf("_" + key + "_") < 0) { tarteaucitron.services[key].js(); }
                 }
+            }
+            var itemStatusElem = document.getElementById('tacCurrentStatus'+key);
+            if(status == true){
+                itemStatusElem.innerHTML = tarteaucitron.lang.allowed;
+            }else{
+                itemStatusElem.innerHTML = tarteaucitron.lang.disallowed;
             }
             tarteaucitron.state[key] = status;
             tarteaucitron.cookie.create(key, status);

--- a/tarteaucitron.js
+++ b/tarteaucitron.js
@@ -596,7 +596,7 @@ var tarteaucitron = {
                 }
                 if(tarteaucitron.parameters.closePopup === true){
                     var closeElement = document.getElementById('tarteaucitronAlertBig'),
-                    closeSpan = document.createElement('span');
+                        closeSpan = document.createElement('span');
                     closeSpan.textContent = 'X';
                     closeSpan.setAttribute('id', "tarteaucitronCloseCross");
                     closeElement.insertBefore(closeSpan, closeElement.firstElementChild);


### PR DESCRIPTION
Le RGAA Critère 3.1 prévoit : " Critère 3.1. Dans chaque page web, l’information ne doit pas être donnée uniquement par la couleur. Cette règle est-elle respectée ?"
https://www.numerique.gouv.fr/publications/rgaa-accessibilite/methode-rgaa/criteres/#topic3
Cette contrainte d'accessibilité n'est pas respectée par Tarte Au Citron car la seule information qui indique quel service est activé est la couleur du bouton.
Ce commit ajoute une mention, à côté du titre du service indiquant l'état courant du service en question.
Les traductions dans les différentes langues ont été faites avec Google Translate