### PR TITLE
feat: add Intercom chat service

### DIFF
--- a/tarteaucitron.services.js
+++ b/tarteaucitron.services.js
@@ -2331,6 +2331,54 @@ tarteaucitron.services.purechat = {
     }
 };
 
+// Intercom
+tarteaucitron.services.intercomChat = {
+    "key": "intercomChat",
+    "type": "support",
+    "name": "Intercom",
+    "uri": "https://www.intercom.com/",
+    "needConsent": true,
+    "cookies": [
+        "intercom-id-" + tarteaucitron.user.ingercomKey,
+        "intercom-session-" + tarteaucitron.user.ingercomKey,
+    ],
+    "readmoreLink": "https://www.intercom.com/legal/privacy",
+    "js": function () {
+        window.intercomSettings = {
+            app_id: tarteaucitron.user.ingercomKey,
+        };
+
+        var w = window;
+        var ic = w.Intercom;
+        if (typeof ic === "function") {
+            ic("reattach_activator");
+            ic("update", w.intercomSettings);
+        } else {
+            var i = function () {
+                i.c(arguments);
+            };
+            i.q = [];
+            i.c = function (args) {
+                i.q.push(args);
+            };
+            w.Intercom = i;
+            tarteaucitron.addScript(
+                "https://widget.intercom.io/widget/" + tarteaucitron.user.intercomKey,
+                "",
+                function () {
+                    // I WOULD LIKE TRIGGER A CALLBACK
+                },
+            );
+        }
+    },
+    "fallback": function () {
+        "use strict";
+        var id = "intercomChat";
+        tarteaucitron.fallback(["intercom-chat"], tarteaucitron.engage(id));
+        // I WOULD LIKE TRIGGER A CALLBACK
+    },
+};
+
 // rumbletalk
 tarteaucitron.services.rumbletalk = {
     "key": "rumbletalk",


### PR DESCRIPTION
@AmauriC 

I've read the Wiki, https://tarteaucitron.io/en/, and quickly the source code, but I don't know how to trigger a callback on success or failure of service loading ?

Could you help me please 😄  ?

Note,

The original script given by Intercom in my space is

```javascript
(function () {
  var w = window;
  var ic = w.Intercom;
  if (typeof ic === 'function') {
    ic('reattach_activator');
    ic('update', w.intercomSettings);
  } else {
    var d = document;
    var i = function () {
      i.c(arguments);
    };
    i.q = [];
    i.c = function (args) {
      i.q.push(args);
    };
    w.Intercom = i;
    var l = function () {
      var s = d.createElement('script');
      s.type = 'text/javascript';
      s.async = true;
      s.src = 'https://widget.intercom.io/widget/SECRET_KEY_XXXXXXXX';
      var x = d.getElementsByTagName('script')[0];
      x.parentNode.insertBefore(s, x);
    };
    if (w.attachEvent) {
      w.attachEvent('onload', l);
    } else {
      w.addEventListener('load', l, false);
    }
  }
})();
```