### PR TITLE
Update Soundcloud, Facebook and Ausha services

### DIFF
--- a/tarteaucitron.services.js
+++ b/tarteaucitron.services.js
@@ -1261,7 +1261,7 @@ tarteaucitron.services.facebook = {
     "name": "Facebook",
     "uri": "https://www.facebook.com/policy.php",
     "needConsent": true,
-    "cookies": [],
+    "cookies": ['xs', 'sb', 'fr', 'datr', 'dpr', 'c_user'],
     "js": function () {
         "use strict";
         tarteaucitron.fallback(['fb-post', 'fb-follow', 'fb-activity', 'fb-send', 'fb-share-button', 'fb-like', 'fb-video'], '');
@@ -2505,7 +2505,7 @@ tarteaucitron.services.soundcloud = {
     type: 'video',
     name: 'SoundCloud',
     needConsent: true,
-    cookies: ['sc_anonymous_id'],
+    cookies: ['sc_anonymous_id', 'sclocale'],
     js: function () {
         "use strict";
         tarteaucitron.fallback(['soundcloud_player'], function (x) {
@@ -4073,7 +4073,7 @@ tarteaucitron.services.ausha = {
     type: "video",
     name: "Ausha",
     uri: "https://www.ausha.co/protection-personal-data/",
-    needConsent: true,
+    needConsent: false,
     cookies: [],
     js: function () {
         "use strict";

--- a/tarteaucitron.services.js
+++ b/tarteaucitron.services.js
@@ -4073,7 +4073,7 @@ tarteaucitron.services.ausha = {
     type: "video",
     name: "Ausha",
     uri: "https://www.ausha.co/protection-personal-data/",
-    needConsent: false,
+    needConsent: true,
     cookies: [],
     js: function () {
         "use strict";


### PR DESCRIPTION
This adds a cookies list for the Facebook service and a second one for Soundcloud.  
Also I set `needConsent` to false for the Ausha service I previsously added as it doesn't seem to use any cookies.