### PR TITLE
Add "main" property to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "tarteaucitronjs",
   "version": "1.9.1",
+  "main": "tarteaucitron.js",
   "description": "Comply to the European cookie law",
   "dependencies": {},
   "devDependencies": {},


### PR DESCRIPTION
Ajout du param "main" dans le package.json pour éviter une erreur "package not found" (https://docs.npmjs.com/cli/v7/configuring-npm/package-json#main)