### PR TITLE
HTML5 compliance for Youtube service

### DIFF
--- a/tarteaucitron.services.js
+++ b/tarteaucitron.services.js
@@ -3446,15 +3446,15 @@ tarteaucitron.services.youtube = {
         "use strict";
         tarteaucitron.fallback(['youtube_player'], function (x) {
             var frame_title = tarteaucitron.fixSelfXSS(x.getAttribute("title") || 'Youtube iframe'),
-                video_id = x.getAttribute("videoID"),
-                srcdoc = x.getAttribute("srcdoc"),
-                loading = x.getAttribute("loading"),
-                video_width = x.getAttribute("width"),
+                video_id = x.getAttribute("data-videoID") || x.getAttribute("videoID"),
+                srcdoc = x.getAttribute("data-srcdoc") || x.getAttribute("srcdoc"),
+                loading = x.getAttribute("data-loading") || x.getAttribute("loading"),
+                video_width = x.getAttribute("data-width") || x.getAttribute("width"),
                 frame_width = 'width=',
-                video_height = x.getAttribute("height"),
+                video_height = x.getAttribute("data-height") || x.getAttribute("height"),
                 frame_height = 'height=',
                 video_frame,
-                allowfullscreen = x.getAttribute("allowfullscreen"),
+                allowfullscreen = x.getAttribute("data-allowfullscreen") || x.getAttribute("allowfullscreen"),
                 attrs = ["theme", "rel", "controls", "showinfo", "autoplay", "mute", "start", "loop"],
                 params = attrs.filter(function (a) {
                   return x.getAttribute(a) !== null;


### PR DESCRIPTION
If we use "videoID" as a custom attribute for YouTube integration, HTML5 validator fails with the message "Error: Attribute videoID not allowed on element div at this point."

We must use data-* prefix to define custom attributes, according to the HTML5 spec : 
https://www.w3.org/TR/html52/dom.html#embedding-custom-non-visible-data-with-the-data-attributes


This commit is inspired by the Vimeo service integration.