### PR TITLE
Add bingadsMore to bingAds service

### DIFF
--- a/tarteaucitron.services.js
+++ b/tarteaucitron.services.js
@@ -3985,6 +3985,10 @@ tarteaucitron.services.bingads = {
             bingadsCreate.q = window.uetq;
             window.uetq = new UET(bingadsCreate);
             window.uetq.push('pageLoad');
+
+            if (typeof tarteaucitron.user.bingadsMore === 'function') {
+                tarteaucitron.user.bingadsMore();
+            }
         });
     }
 };


### PR DESCRIPTION
In order to be able to send some e-commerce values like : 
```js
window.uetq = window.uetq || [];
window.uetq.push ('event', '', {'revenue_value': 100.00 });  
```

Using : 
```js
tarteaucitron.user.bingAdsMore = function () { 
    window.uetq = window.uetq || [];
    window.uetq.push('event', '', { 'revenue_value': 100.00 });
}
```