### PR TITLE
add canal-u.tv service

### DIFF
--- a/tarteaucitron.services.js
+++ b/tarteaucitron.services.js
@@ -4751,3 +4751,34 @@ tarteaucitron.services.marketomunchkin = {
         document.getElementsByTagName('head')[0].appendChild(s);
     }
 }
+// Canal-U.tv
+tarteaucitron.services.canalu = {
+    "key": "canalu",
+    "type": "video",
+    "name": "Canal-U.tv",
+    "uri": "https://www.canal-u.tv/utilisation-des-cookies/",
+    "needConsent": true,
+    "cookies": [],
+    "js": function () {
+        "use strict";
+        tarteaucitron.fallback(['canalu_player'], function (x) {
+            var video_title = tarteaucitron.fixSelfXSS(x.getAttribute("videoTitle")),
+                frame_url = 'https://www.canal-u.tv/video/embed_code_plugin.1/' + video_title;
+
+            return '<div style="position:relative;padding-bottom:56.25%;padding-top:10px;height:0;overflow:hidden;">' +
+                   '<iframe src="' + frame_url + '?width=100%&amp;height=100%" ' +
+                        'style="position:absolute;top:0;left:0;width:100%;height: 100%;" ' +
+                        'frameborder="0" ' +
+                        'allowfullscreen ' +
+                        'scrolling="no">' +
+                   '</iframe>' +
+                   '</div>';
+        });
+    },
+    "fallback": function () {
+        "use strict";
+        tarteaucitron.fallback(['canalu_player'], function (elem) {
+            return tarteaucitron.engage('canalu');
+        });
+    }
+};


### PR DESCRIPTION
Here is a minimal implementation for the french video streaming Canal-U.tv. This is a streaming service for french universities.

The template should look like : 
`<div class="canalu_player" videoTitle="node_red_pour_l_instrumentation_des_bancs_de_catalyse_de_l_ircelyon.63141"></div>`

For the URL below : 
`https://www.canal-u.tv/video/rde/node_red_pour_l_instrumentation_des_bancs_de_catalyse_de_l_ircelyon.63141`