### PR TITLE
Add2AnyShare - Suppression de l'élément DOM lorsque le service est autorisé

### DIFF
--- a/tarteaucitron.services.js
+++ b/tarteaucitron.services.js
@@ -563,7 +563,9 @@ tarteaucitron.services.addtoanyshare = {
     "cookies": [],
     "js": function () {
         "use strict";
-        tarteaucitron.fallback(['tac_addtoanyshare'], '');
+        tarteaucitron.fallback(['tac_addtoanyshare'], function (elem) {
+            elem.remove();
+        }, true);
         tarteaucitron.addScript('//static.addtoany.com/menu/page.js');
     },
     "fallback": function () {


### PR DESCRIPTION
Bonjour à tous !

Cette nouvelle PR a pour but de supprimer du DOM l'élément TAC du service *add2anyshare* lorsque le celui-ci est autorisé.

Dans notre cas, la présence de la div nous empêche de masquer proprement (via css) le menu de partage lorsque le cookie n'est pas autorisé.
Exemple :
``` css
.tac_addtoanyshare + button {}
```
_Ce sélecteur fonctionne dans tous les cas, que le service soit autorisé ou non._

Bon week-end ;)