### PR TITLE
[ACCESSIBILITE]Correction des problèmes de contrastes

### DIFF
--- a/css/tarteaucitron.css
+++ b/css/tarteaucitron.css
@@ -548,11 +548,16 @@ div#tarteaucitronServices {
     opacity: 1;
 }
 
-#tarteaucitron #tarteaucitronServices .tarteaucitronLine.tarteaucitronIsAllowed .tarteaucitronAllow {
+#tarteaucitron #tarteaucitronServices .tarteaucitronLine.tarteaucitronIsAllowed .tarteaucitronAllow,
+#tarteaucitron #tarteaucitronServices #tarteaucitronServices_mandatory .tarteaucitronLine button.tarteaucitronAllow {
     background-color: #1B870B;
 }
 #tarteaucitron #tarteaucitronServices .tarteaucitronLine.tarteaucitronIsDenied .tarteaucitronDeny {
     background-color: #9C1A1A;
+}
+
+#tarteaucitron #tarteaucitronServices #tarteaucitronServices_mandatory .tarteaucitronLine button.tarteaucitronAllow{
+    opacity: 0.4;
 }
 
 #tarteaucitron #tarteaucitronServices .tarteaucitronLine .tarteaucitronName .tarteaucitronListCookies {


### PR DESCRIPTION
Cette correction vise à corriger les problèmes de contrastes des boutons d'action.
J'ai supprimé les effets d'opacité sur les boutons désactivés et j'ai remplacé la couleur grise car le texte blanc n'était pas assez contrasté.