### PR TITLE
Documentation about possible customization without hacking code

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,9 @@ tarteaucitron.init({
 </script>
 ```
 
-# Create custom service
+# Customization
+
+## Create custom service
 ```js
 tarteaucitron.services.mycustomservice = {
   "key": "mycustomservice",
@@ -88,7 +90,38 @@ tarteaucitron.services.mycustomservice = {
 };
 ```
 
-## Thanks to the sponsors 😊
+## Events
+
+The following events are available:
+* `tac.root_available`: the root element with panel has been created, services will be loaded
+* {SERVICE_KEY}`.added` for each enabled service
+* {SERVICE_KEY}`.loaded` for each enabled service
+* `tac.open_alert`
+* `tac.close_alert`
+* `tac.open_panel`
+* `tac.close_panel`
+
+## Customize text
+
+To change a translation, use `tarteaucitronCustomText` variable. It will be merge with the translation shipping with TAC. This variable must be defined before the initialization. For example:
+```js
+tarteaucitronCustomText = {
+  'support': {
+    'title': 'Support client',
+  },
+  'close': 'Enregistrer et fermer',
+};
+tarteaucitron.init(...);
+```
+
+There is a special case for engagement text. By the default, the engagement text is  _{SERVICE_NAME} is disabled._, however you can change it per service. For example:
+```js
+tarteaucitronCustomText = {
+  'engage-twitter': 'Follow us on Twitter!'
+};
+```
+
+# Thanks to the sponsors 😊
 
 | Be the first sponsor! |
 |:---:|


### PR DESCRIPTION
Hello,

Thank you for this great tool, with many hidden options ;-) (I had hard time tweaking it without changing the code, because it would make update more difficult). So here is my first attempt to document my finding.

When all options are documented, my next step would be organize the customization. For example, currently `tarteaucitronCustomText` is a bit random, there are translations and there are also customized text. Also, as far as I can tell, there is no way to customize service name (impossible to rename "Google Analytics (ga.js)" to "Google Analytics").