### PR TITLE
Add Gallica to services

### DIFF
--- a/tarteaucitron.services.js
+++ b/tarteaucitron.services.js
@@ -5000,3 +5000,35 @@ tarteaucitron.services.mtcaptcha = {
         tarteaucitron.addScript('https://service2.mtcaptcha.com/mtcv1/client/mtcaptcha2.min.js');
     }
 };
+
+// Gallica
+tarteaucitron.services.gallica = {
+    "key": "gallica",
+    "type": "other",
+    "name": "Gallica",
+    "uri": "https://gallica.bnf.fr/edit/und/conditions-dutilisation-des-contenus-de-gallica",
+    "needConsent": true,
+    "cookies": ['dtCookie', 'dtLatC', 'dtPC', 'dtSa', 'JSESSIONID', 'rxVisitor', 'rxvt', 'xtvrn'],
+    "js": function () {
+        "use strict";
+        tarteaucitron.fallback(['gallica_player'], function (x) {
+            var src = tarteaucitron.getElemAttr(x, "data-src"),
+                style = tarteaucitron.getElemAttr(x, "data-style"),
+                frame;
+            if (src === undefined) {
+                return "";
+            }
+            frame = '<iframe style="'+ style + '" src="' + src + '"></iframe>';
+            return frame;
+        });
+    },
+    "fallback": function () {
+        "use strict";
+        var id = 'gallica';
+        tarteaucitron.fallback(['gallica_player'], function (elem) {
+            elem.style = elem.getAttribute('data-style');
+            return tarteaucitron.engage(id);
+        });
+    }
+};
+


### PR DESCRIPTION
Original Gallica share iframe looks like: 
`<div style="display: block; "><iframe style="width:500px; height: 585.3967775937359px; border: 0;" src="https://gallica.bnf.fr/ark:/12148/btv1b53159105r/f1.item.mini"></iframe></div>`

It must be converted to: 
`<div data-style="width:500px; height: 585.3967775937359px; border: 0;" data-src="https://gallica.bnf.fr/ark:/12148/btv1b53159105r/f1.item.mini"></div>`

Example source: https://gallica.bnf.fr/ark:/12148/btv1b53159105r#
