### PR TITLE
Services Vimeo et Youtube conditional usage of HTML valid videoID attributes

### DIFF
--- a/tarteaucitron.services.js
+++ b/tarteaucitron.services.js
@@ -3443,7 +3443,7 @@ tarteaucitron.services.youtube = {
         "use strict";
         tarteaucitron.fallback(['youtube_player'], function (x) {
             var frame_title = tarteaucitron.fixSelfXSS(tarteaucitron.getElemAttr(x, "title") || 'Youtube iframe'),
-                video_id = tarteaucitron.getElemAttr(x, "videoID"),
+                tarteaucitron.getElemAttr(x, "data-videoID") || tarteaucitron.getElemAttr(x, "videoID"),
                 srcdoc = tarteaucitron.getElemAttr(x, "srcdoc"),
                 loading = tarteaucitron.getElemAttr(x, "loading"),
                 video_width = tarteaucitron.getElemAttr(x, "width"),

--- a/tarteaucitron.services.js
+++ b/tarteaucitron.services.js
@@ -3443,7 +3443,7 @@ tarteaucitron.services.youtube = {
         "use strict";
         tarteaucitron.fallback(['youtube_player'], function (x) {
             var frame_title = tarteaucitron.fixSelfXSS(tarteaucitron.getElemAttr(x, "title") || 'Youtube iframe'),
-                tarteaucitron.getElemAttr(x, "data-videoID") || tarteaucitron.getElemAttr(x, "videoID"),
+                video_id = tarteaucitron.getElemAttr(x, "data-videoID") || tarteaucitron.getElemAttr(x, "videoID"),
                 srcdoc = tarteaucitron.getElemAttr(x, "srcdoc"),
                 loading = tarteaucitron.getElemAttr(x, "loading"),
                 video_width = tarteaucitron.getElemAttr(x, "width"),

--- a/tarteaucitron.services.js
+++ b/tarteaucitron.services.js
@@ -3153,7 +3153,7 @@ tarteaucitron.services.vimeo = {
                 video_height = tarteaucitron.getElemAttr(x, "height"),
                 frame_height = 'height=',
 
-                video_id = tarteaucitron.getElemAttr(x, "videoID"),
+                video_id = tarteaucitron.getElemAttr(x, "data-videoID") || tarteaucitron.getElemAttr(x, "videoID"),
                 video_hash = tarteaucitron.getElemAttr(x, "data-hash") || '',
                 video_allowfullscreen = tarteaucitron.getElemAttr(x, "data-allowfullscreen"),
 


### PR DESCRIPTION
[BUGFIX]Services > Vimeo > Revert of deletion of the usage of attribute (removed in https://github.com/AmauriC/tarteaucitron.js/commit/ebbc358fbd06e0f226d3a8f51b6159ddc5ef05ce )
[TASK]Services > Youtube > Add usage of attribute data-videoID for html validity