### PR TITLE
Allow global and per service default state. Open the alert only on 'w…

### DIFF
--- a/tarteaucitron.js
+++ b/tarteaucitron.js
@@ -221,7 +221,8 @@ var tarteaucitron = {
                 "useExternalJs": false,
                 "mandatory": true,
                 "closePopup": false,
-                "groupServices": false
+                "groupServices": false,
+                "serviceDefaultState": 'wait',
             },
             params = tarteaucitron.parameters;
 
@@ -865,12 +866,15 @@ var tarteaucitron = {
             tarteaucitron.state[service.key] = false;
             tarteaucitron.userInterface.color(service.key, false);
         } else if (!isResponded) {
-            tarteaucitron.cookie.create(service.key, 'wait');
+            tarteaucitron.cookie.create(service.key, service.defaultState || tarteaucitron.parameters.serviceDefaultState);
             if (typeof service.fallback === 'function') {
                 if (typeof tarteaucitronMagic === 'undefined' || tarteaucitronMagic.indexOf("_" + service.key + "_") < 0) { service.fallback(); }
             }
-            tarteaucitron.userInterface.color(service.key, 'wait');
-            tarteaucitron.userInterface.openAlert();
+            tarteaucitron.userInterface.color(service.key, service.defaultState || tarteaucitron.parameters.serviceDefaultState);
+
+            if( 'wait' === (service.defaultState || tarteaucitron.parameters.serviceDefaultState) ) {
+                tarteaucitron.userInterface.openAlert();
+            }
         }
 
         tarteaucitron.cookie.checkCount(service.key);


### PR DESCRIPTION
This allows globally or per service's default state.

The use case is when you have anonymous analytics (that do not need consent) and setup on-demand services activation. If the alert get shown, the risk is that visitors click the "Deny all cookies", disabling also the analytics tool ...

By having third parties services disabled by default, the alert doesn't show up and visitors can enable services when they need and want, using the on-demand service loading feature.

- This commit adds a new `serviceDefaultState` global options (@todo to be documented)
- This commit adds a new `defaultState` option to services configuration.

How to use globally:
```html
<script>
tarteaucitron.init({
    ...
    "serviceDefaultState": 'false' // or 'true' or 'wait'. Defaults to 'wait'
    ...
});
</script>
```

How to use per service:
```html
<script>
tarteaucitron.services.twitter.defaultState = 'false' // or 'true' or 'wait'. Defaults to globat setting.
</script>
```

