### PR TITLE
[HOTFIX/884]Fixes Uncaught TypeError: Cannot read properties of null …

### DIFF
--- a/tarteaucitron.services.js
+++ b/tarteaucitron.services.js
@@ -12,7 +12,7 @@ tarteaucitron.services.iframe = {
     "js": function () {
         "use strict";
         tarteaucitron.fallback(['tac_iframe'], function (x) {
-            var frame_title = tarteaucitron.fixSelfXSS(x.getAttribute("title")),
+            var frame_title = (x.getAttribute("title")) ? tarteaucitron.fixSelfXSS(x.getAttribute("title")) : '',
                 width = x.getAttribute("width"),
                 height = x.getAttribute("height"),
                 allowfullscreen = x.getAttribute("allowfullscreen"),


### PR DESCRIPTION
…(reading 'toString') at Object.fixSelfXSS (tarteaucitron.js?1638786396:1772:21)

if tac_iframe does not have any title fixSelfXss fails.
This commit fixes #884