### PR TITLE
Accessibilité : Supprime attribut aria-describedby inutile

### DIFF
--- a/tarteaucitron.js
+++ b/tarteaucitron.js
@@ -318,7 +318,7 @@ var tarteaucitron = {
                 } else {
                     html += '<button type="button" id="tarteaucitronBack" aria-label="' + tarteaucitron.lang.close + '" title="' + tarteaucitron.lang.close + '"></button>';
                 }
-                html += '<div id="tarteaucitron" role="dialog" aria-modal="true" aria-describedby="tarteaucitronInfo" aria-labelledby="dialogTitle" tabindex="-1">';
+                html += '<div id="tarteaucitron" role="dialog" aria-modal="true" aria-labelledby="dialogTitle" tabindex="-1">';
                 if (tarteaucitron.reloadThePage) {
                     html += '   <button type="button" id="tarteaucitronClosePanel" aria-label="' + tarteaucitron.lang.close + ' (' + tarteaucitron.lang.reload + ')" title="' + tarteaucitron.lang.close + ' (' + tarteaucitron.lang.reload + ')">';
                 } else {


### PR DESCRIPTION
L'attribut aria-labelledby est suffisant pour annoncer le contenu de la modale.