### PR TITLE
Accessibility : Add option to show/hide disabled accept button in mandatory

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,8 @@ tarteaucitron.init({
 
     "readmoreLink": "", /* Change the default readmore link pointing to tarteaucitron.io */
     
-    "mandatory": true /* Show a message about mandatory cookies */
+    "mandatory": true, /* Show a message about mandatory cookies */
+    "mandatoryCta": true /* Show the disabled accept button when mandatory on */
 });
 </script>
 ```

--- a/tarteaucitron.js
+++ b/tarteaucitron.js
@@ -220,6 +220,7 @@ var tarteaucitron = {
                 "useExternalCss": false,
                 "useExternalJs": false,
                 "mandatory": true,
+                "mandatoryCta": true,
                 "closePopup": false,
                 "groupServices": false,
                 "serviceDefaultState": 'wait',
@@ -365,14 +366,16 @@ var tarteaucitron = {
                    html += '       <span class="tarteaucitronH3" role="heading" aria-level="3">' + tarteaucitron.lang.mandatoryText + '</span>';
                    html += '       <span class="tarteaucitronListCookies" aria-hidden="true"></span><br/>';
                    html += '   </div>';
-                   html += '   <div class="tarteaucitronAsk">';
-                   html += '       <button type="button" class="tarteaucitronAllow" tabindex="-1" disabled>';
-                   html += '           <span class="tarteaucitronCheck" aria-hidden="true"></span> ' + tarteaucitron.lang.allow;
-                   html += '       </button> ';
-                   html += '       <button type="button" class="tarteaucitronDeny" style="visibility:hidden" tabindex="-1">';
-                   html += '           <span class="tarteaucitronCross" aria-hidden="true"></span> ' + tarteaucitron.lang.deny;
-                   html += '       </button> ';
-                   html += '   </div>';
+                   if (tarteaucitron.parameters.mandatoryCta == true) {
+                       html += '   <div class="tarteaucitronAsk">';
+                       html += '       <button type="button" class="tarteaucitronAllow" tabindex="-1" disabled>';
+                       html += '           <span class="tarteaucitronCheck" aria-hidden="true"></span> ' + tarteaucitron.lang.allow;
+                       html += '       </button> ';
+                       html += '       <button type="button" class="tarteaucitronDeny" style="visibility:hidden" tabindex="-1">';
+                       html += '           <span class="tarteaucitronCross" aria-hidden="true"></span> ' + tarteaucitron.lang.deny;
+                       html += '       </button> ';
+                       html += '   </div>';
+                   }
                    html += '</li>';
                    html += '</ul></li>';
                 }


### PR DESCRIPTION
The addition of this option simplifies the screen and the possible interactions in the case where the site editor wants to display the "Mandatory Cookies" section, but not the Accept/Refuse buttons.
This allows you to have the explanatory text, but not the associated buttons, which in reality are not usable. The interface is finally clearer and more understandable in most cases.