### PR TITLE
Ajoute une option pour afficher un titre sur la bannière

### DIFF
--- a/css/tarteaucitron.css
+++ b/css/tarteaucitron.css
@@ -586,7 +586,8 @@ div#tarteaucitronServices {
     margin-left: 0!important;
     font-size: 14px;
 }
-span#tarteaucitronDisclaimerAlert {
+span#tarteaucitronDisclaimerAlert,
+h2#tarteaucitronDisclaimerAlertTitle {
     padding: 0 10px;
     display: inline-block;
 }
@@ -618,6 +619,14 @@ span#tarteaucitronDisclaimerAlert {
     padding: 10px 0 10px 0;
     margin: auto;
     width: 100%;
+}
+
+#tarteaucitronAlertBig #tarteaucitronDisclaimerAlertTitle {
+    display: block;
+    font: 15px verdana;
+    color: #fff;
+    font-weight: 700;
+    text-align: center;
 }
 
 #tarteaucitronAlertBig #tarteaucitronPrivacyUrl,

--- a/lang/tarteaucitron.en.js
+++ b/lang/tarteaucitron.en.js
@@ -8,7 +8,8 @@ tarteaucitron.lang = {
     "alertBigScroll": "By continuing to scroll,",
     "alertBigClick": "If you continue to browse this website,",
     "alertBig": "you are allowing all third-party services",
-    
+
+    "alertBigPrivacyTitle": "This site uses cookies",
     "alertBigPrivacy": "This site uses cookies and gives you control over what you want to activate",
     "alertSmall": "Manage services",
     "personalize": "Personalize",

--- a/lang/tarteaucitron.fr.js
+++ b/lang/tarteaucitron.fr.js
@@ -9,7 +9,8 @@ tarteaucitron.lang = {
     "alertBigScroll": "En continuant de défiler,",
     "alertBigClick": "En poursuivant votre navigation,",
     "alertBig": "vous acceptez l'utilisation de services tiers pouvant installer des cookies",
-    
+
+    "alertBigPrivacyTitle": "Ce site utilise des cookies",
     "alertBigPrivacy": "Ce site utilise des cookies et vous donne le contrôle sur ceux que vous souhaitez activer",
     "alertSmall": "Gestion des services",
     "acceptAll": "Tout accepter",

--- a/tarteaucitron.js
+++ b/tarteaucitron.js
@@ -224,6 +224,7 @@ var tarteaucitron = {
                 "closePopup": false,
                 "groupServices": false,
                 "serviceDefaultState": 'wait',
+                "alertBigPrivacyTitle": false,
             },
             params = tarteaucitron.parameters;
 
@@ -272,7 +273,7 @@ var tarteaucitron = {
                 // css for the middle bar TODO: add it on the css file
                 if (tarteaucitron.orientation === 'middle') {
                     var customThemeMiddle = document.createElement('style'),
-                        cssRuleMiddle = 'div#tarteaucitronRoot.tarteaucitronBeforeVisible:before {content: \'\';position: fixed;width: 100%;height: 100%;background: white;top: 0;left: 0;z-index: 999;opacity: 0.5;}div#tarteaucitronAlertBig:before {content: \'' + tarteaucitron.lang.middleBarHead + '\';font-size: 35px;}body #tarteaucitronRoot div#tarteaucitronAlertBig {width: 60%;min-width: 285px;height: auto;margin: auto;left: 50%;top: 50%;transform: translate(-50%, -50%);box-shadow: 0 0 9000px #000;border-radius: 20px;padding: 35px 25px;}span#tarteaucitronDisclaimerAlert {padding: 0 30px;}#tarteaucitronRoot span#tarteaucitronDisclaimerAlert {margin: 10px 0 30px;display: block;text-align: center;font-size: 21px;}@media screen and (max-width: 900px) {div#tarteaucitronAlertBig button {margin: 0 auto 10px!important;display: block!important;}}';
+                        cssRuleMiddle = 'div#tarteaucitronRoot.tarteaucitronBeforeVisible:before {content: \'\';position: fixed;width: 100%;height: 100%;background: white;top: 0;left: 0;z-index: 999;opacity: 0.5;}div#tarteaucitronAlertBig:before {content: \'' + tarteaucitron.lang.middleBarHead + '\';font-size: 35px;}body #tarteaucitronRoot div#tarteaucitronAlertBig {width: 60%;min-width: 285px;height: auto;margin: auto;left: 50%;top: 50%;transform: translate(-50%, -50%);box-shadow: 0 0 9000px #000;border-radius: 20px;padding: 35px 25px;}span#tarteaucitronDisclaimerAlert {padding: 0 30px;}#tarteaucitronAlertBig #tarteaucitronDisclaimerAlertTitle {font-size: 21px;}#tarteaucitronRoot span#tarteaucitronDisclaimerAlert {margin: 10px 0 30px;display: block;text-align: center;font-size: 21px;}@media screen and (max-width: 900px) {div#tarteaucitronAlertBig button {margin: 0 auto 10px!important;display: block!important;}}';
 
                     customThemeMiddle.type = 'text/css';
                     if (customThemeMiddle.styleSheet) {
@@ -407,6 +408,9 @@ var tarteaucitron = {
                 if (tarteaucitron.parameters.highPrivacy && !tarteaucitron.parameters.AcceptAllCta) {
                     html += '<div tabindex="-1" id="tarteaucitronAlertBig" class="tarteaucitronAlertBig' + orientation + '">';
                     //html += '<div class="tarteaucitronAlertBigWrapper">';
+                    if (tarteaucitron.parameters.alertBigPrivacyTitle) {
+                        html += '   <h2 tabindex="0" id="tarteaucitronDisclaimerAlertTitle">' + tarteaucitron.lang.alertBigPrivacyTitle + '</h2>';
+                    }
                     html += '   <span id="tarteaucitronDisclaimerAlert">';
                     html += '       ' + tarteaucitron.lang.alertBigPrivacy;
                     html += '   </span>';
@@ -427,6 +431,9 @@ var tarteaucitron = {
                 } else {
                     html += '<div tabindex="-1" id="tarteaucitronAlertBig" class="tarteaucitronAlertBig' + orientation + '">';
                     //html += '<div class="tarteaucitronAlertBigWrapper">';
+                    if (tarteaucitron.parameters.alertBigPrivacyTitle) {
+                        html += '   <h2 tabindex="0" id="tarteaucitronDisclaimerAlertTitle">' + tarteaucitron.lang.alertBigPrivacyTitle + '</h2>';
+                    }
                     html += '   <span id="tarteaucitronDisclaimerAlert">';
 
                     if (tarteaucitron.parameters.highPrivacy) {
@@ -1374,7 +1381,11 @@ var tarteaucitron = {
             //end ie compatibility
 
             if (document.getElementById('tarteaucitronAlertBig') !== null) {
-                document.getElementById('tarteaucitronAlertBig').focus();
+                if (tarteaucitron.parameters.alertBigPrivacyTitle) {
+                    document.getElementById('tarteaucitronDisclaimerAlertTitle').focus();
+                } else {
+                    document.getElementById('tarteaucitronAlertBig').focus();
+                }
             }
 
             if (typeof(window.dispatchEvent) === 'function') {window.dispatchEvent(tacOpenAlertEvent);}


### PR DESCRIPTION
Cet ajout a pour but de permettre à un lecteur d'écran d'identifier de quoi traite le paragraphe de la bannière et d'éviter éventuellement la lecture du paragraphe dans son intégralité.

- Ajout d'une balise de titre `<h2>` au-dessus du paragraphe explicatif du bandeau cookie. 
- Ce titre sera facultatif via l'option "alertBigPrivacyTitle". S'il n'est pas défini, il n'y aura pas de `<h2>` généré.
- A l'arrivée sur la page, le focus sera déplacé sur le tag `<h2> `s'il existe, sinon le fonctionnement sera inchangé par rapport à l'existant.

Plusieurs points à voir cependant :

1/ Votre point de vue sur la pertinence de cet ajout.

2/ Par défaut, si l'option est activée, le texte sera "Ce site utilise des cookies", présent dans les fichiers de langue FR et EN dans cette PR. Comment gérez vous les différentes traductions dans les autres fichiers langues ?

3/ Le choix a été fait de mettre ce titre dans une balise `<h2>`. Mais d'un point de vue hierarchie de l'information, cela peut faire sens d'utiliser plutôt une balise `<h1>`, puisqu'on se retrouve avec une zone différente, "en dehors" de la vraie hierarchie de la page. 

Par contre d'un point de vue SEO, la situation est plus complexe : le contenu fait partie d'un composant JS, il n'est pas vraiment sur qu'il soit indexer par tous les moteurs de recherche en l'état, mais il semble de plus en plus être pris en compte… et ce qui est sur c'est que les moteurs de recherche ne gère pas de cookie, ce qui signifie que la bannière sera présente sur toutes les pages. 

En termes de SEO, la balise H1 est surtout réservée pour du contenu en rapport avec la page. Si plusieurs utilisations de balises `<h1>` est à prévoir, il vaut mieux réserver cela pour des titres avec des mots-clés en rapport avec le contenu, plutôt qu'un élément annexe comme le bandeau de cookies.

Si Google affirme que l'utilisation de plusieurs balises H1 ne gênerait pas si elle est utilisée pour l'accessibilité, je pense cependant que placer plusieurs balises peut donner un signe de suroptimisation aux yeux des moteurs de recherche car présente sur toutes les pages. (Même si l'algorithme de Google évolue, nous avons toujours affaire à des robots qui lisent du code :) ).

Et donc est ce qu'il serait intéressant de proposer également une option pour choisir le tag souhaité ?

