### PR TITLE
Always load Twitter script with HTTPS

### DIFF
--- a/tarteaucitron.services.js
+++ b/tarteaucitron.services.js
@@ -3896,7 +3896,7 @@ tarteaucitron.services.twittertimeline = {
     "js": function () {
         "use strict";
         tarteaucitron.fallback(['tacTwitterTimelines'], '');
-        tarteaucitron.addScript('//platform.twitter.com/widgets.js', 'twitter-wjs');
+        tarteaucitron.addScript('https://platform.twitter.com/widgets.js', 'twitter-wjs');
     },
     "fallback": function () {
         "use strict";


### PR DESCRIPTION
It is a good practice to always load the script with HTTPS if available.