### PR TITLE
[FIX] Fix Google Fonts service

### DIFF
--- a/tarteaucitron.services.js
+++ b/tarteaucitron.services.js
@@ -2963,7 +2963,7 @@ tarteaucitron.services.googlefonts = {
         tarteaucitron.addScript('//ajax.googleapis.com/ajax/libs/webfont/1.6.26/webfont.js', '', function () {
             WebFont.load({
                 google: {
-                    families: tarteaucitron.user.googleFonts
+                    families: [tarteaucitron.user.googleFonts]
                 }
             });
         });


### PR DESCRIPTION
When using the Google Fonts service, the `WebFont.load` function may generate a 400 error.  
![image](https://user-images.githubusercontent.com/57016732/226887224-6099edb1-5758-48ab-b223-12ee5d968817.png)  
This error is due to the fact that brackets must surround the font family provided in the object passed in parameter.