### PR TITLE
Update tarteaucitron.js

### DIFF
--- a/tarteaucitron.js
+++ b/tarteaucitron.js
@@ -1821,8 +1821,8 @@ var tarteaucitron = {
         }
 
         // get the html lang
-        if (availableLanguages.indexOf(document.documentElement.getAttribute("lang")) !== -1) {
-            return document.documentElement.getAttribute("lang");
+        if (availableLanguages.indexOf(document.documentElement.getAttribute("lang").substr(0, 2)) !== -1) {
+          return document.documentElement.getAttribute("lang").substr(0, 2);
         }
 
         if (!navigator) { return defaultLanguage; }


### PR DESCRIPTION
problème pour récupérer la langue depuis la balise <html lang="en-US"> par exemple, on prend bien juste les deux premier caractères comme fait quand on récupère la langue du navigateur