### PR TITLE
tarteaucitron.js: Now using document.currentScript if available

### DIFF
--- a/tarteaucitron.js
+++ b/tarteaucitron.js
@@ -1,7 +1,7 @@
 /*jslint browser: true, evil: true */
 
 var scripts = document.getElementsByTagName('script'),
-    path = scripts[scripts.length - 1].src.split('?')[0],
+    path = (document.currentScript || scripts[scripts.length - 1]).src.split('?')[0],
     tarteaucitronForceCDN = (tarteaucitronForceCDN === undefined) ? '' : tarteaucitronForceCDN,
     cdn = (tarteaucitronForceCDN === '') ? path.split('/').slice(0, -1).join('/') + '/' : tarteaucitronForceCDN,
     alreadyLaunch = (alreadyLaunch === undefined) ? 0 : alreadyLaunch,


### PR DESCRIPTION
Getting the current script with `scripts[scripts.length-1]` may not always work. It doesn't for me at least, on https://www.foreverliving.fr/my-forever.html using Firefox (It returns the next script, not the current one). It has been bugging me out for a year now...

This PR uses `document.currentScript` and reverts back to the old method if this feature is not available on the browser.