### PR TITLE
Allow adding a custom description for each service

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,13 @@ tarteaucitronCustomText = {
 };
 ```
 
+It is also possible to add custom text describing each service:
+```js
+tarteaucitronCustomText = {
+  'more-twitter': 'We use this to display a tweet button'
+};
+```
+
 # Thanks to the sponsors 😊
 
 | ![Amaury Cleuziou](https://avatars.githubusercontent.com/u/26336203?v=4&s=60) | ![Peak Crypto](https://tarteaucitron.io/img/logo_peakcrypto.png)  |   |

--- a/tarteaucitron.js
+++ b/tarteaucitron.js
@@ -810,7 +810,11 @@ var tarteaucitron = {
             html += '       <span class="tarteaucitronH3" role="heading" aria-level="3">' + service.name + '</span>';
             html += '       <span class="tacCurrentStatus" id="tacCurrentStatus' + service.key + '">'+currentStatus+'</span>';
             html += '       <span class="tarteaucitronReadmoreSeparator"> - </span>';
-            html += '       <span id="tacCL' + service.key + '" class="tarteaucitronListCookies"></span><br/>';
+            html += '       <span id="tacCL' + service.key + '" class="tarteaucitronListCookies">';
+            if (tarteaucitron.lang['more-' + service.key] !== undefined) {
+                html += tarteaucitron.lang['more-' + service.key];
+            }
+            html += '</span><br/>';
             if (tarteaucitron.parameters.moreInfoLink == true) {
 
                 var link = 'https://tarteaucitron.io/service/' + service.key + '/';
@@ -1174,7 +1178,11 @@ var tarteaucitron = {
 
             if (status === true) {
                 if (document.getElementById('tacCL' + key) !== null) {
-                    document.getElementById('tacCL' + key).innerHTML = '...';
+                    if (tarteaucitron.lang['more-' + key] !== undefined && tarteaucitron.lang['more-' + key] !== '' ) {
+                        document.getElementById('tacCL' + key).innerHTML = tarteaucitron.lang['more-' + key];
+                    } else {
+                        document.getElementById('tacCL' + key).innerHTML = '...';
+                    }
                 }
                 setTimeout(function () {
                     tarteaucitron.cookie.checkCount(key);
@@ -1702,7 +1710,11 @@ var tarteaucitron = {
             }
 
             if (document.getElementById('tacCL' + key) !== null) {
-                document.getElementById('tacCL' + key).innerHTML = html;
+                if (tarteaucitron.lang['more-' + key] !== undefined && tarteaucitron.lang['more-' + key] !== '' ) {
+                    document.getElementById('tacCL' + key).innerHTML = tarteaucitron.lang['more-' + key] + '<br>' + html;
+                } else {
+                    document.getElementById('tacCL' + key).innerHTML = html;
+                }
             }
         },
         "crossIndexOf": function (arr, match) {


### PR DESCRIPTION
Some context: the [tacjs module](https://www.drupal.org/project/tacjs) allows using and customizing tarteaucitron on Drupal.
It does one thing that regular tarteaucitron does not: add a custom text for each service (this is useful for example if you need to explain to your users what you are doing  with each service).

It does this by [providing a patched copy of tarteaucitron.js.](https://www.drupal.org/project/tacjs/issues/3372200) IMHO this is a bad practice so it would be better if this functionality could be provided directly by tarteaucitron.

So the goal of this PR is to integrate the changes made by tacjs directly into tarteaucitron.

(I converted the patch without changing the logic but I am not entirely sure inserting the text in `addService()` is needed. I think it will always be overridden by `checkCount()`.
You might also want to use a separate `span` with a different class for this, instead of injecting it in `tarteaucitronListCookies`.)