### PR TITLE
Cookie details on click or not

### DIFF
--- a/css/tarteaucitron.css
+++ b/css/tarteaucitron.css
@@ -421,7 +421,8 @@ div#tarteaucitronServices {
 #tarteaucitronAlertSmall #tarteaucitronCookiesListContainer #tarteaucitronCookiesList .tarteaucitronTitle,
 #tarteaucitron #tarteaucitronServices .tarteaucitronTitle button,
 #tarteaucitron #tarteaucitronInfo,
-#tarteaucitron #tarteaucitronServices .tarteaucitronDetails {
+#tarteaucitron #tarteaucitronServices .tarteaucitronDetails,
+#tarteaucitronRoot .asCatToggleBtn {
     color: #fff;
     display: inline-block;
     font-size: 14px;
@@ -458,7 +459,7 @@ div#tarteaucitronServices {
 }
 
 #tarteaucitron #tarteaucitronInfo,
-#tarteaucitron #tarteaucitronServices .tarteaucitronDetails {
+#tarteaucitron #tarteaucitronServices .tarteaucitronDetails:not(.tarteaucitronDetailsInline) {
     color: #fff;
     display: none;
     font-size: 12px;
@@ -468,6 +469,15 @@ div#tarteaucitronServices {
     padding: 20px;
     position: absolute;
     z-index: 2147483647;
+}
+
+#tarteaucitron #tarteaucitronServices .tarteaucitronTitle + [id^="tarteaucitronDetails"] {
+    width: 100%;
+    font-weight:500;
+    margin:0;
+    padding:1.5rem;
+    background:rgba(51, 51, 51, 0.2);
+    color:#333;
 }
 
 #tarteaucitron #tarteaucitronInfo a {

--- a/tarteaucitron.js
+++ b/tarteaucitron.js
@@ -362,7 +362,7 @@ var tarteaucitron = {
                     if(tarteaucitron.parameters.showDetailsOnClick){
                         html += '   <button type="button" tabindex="-1"><span class="tarteaucitronPlus" aria-hidden="true"></span> ' + tarteaucitron.lang.mandatoryTitle + '</button>';
                     }else{
-                        html += '   <span>' + tarteaucitron.lang.mandatoryTitle + '</span>';
+                        html += '   <span class="asCatToggleBtn">' + tarteaucitron.lang.mandatoryTitle + '</span>';
                     }
                    html += '</div>';
                    html += '<ul id="tarteaucitronServices_mandatory">';

--- a/tarteaucitron.js
+++ b/tarteaucitron.js
@@ -359,7 +359,11 @@ var tarteaucitron = {
                 if (tarteaucitron.parameters.mandatory == true) {
                    html += '<li id="tarteaucitronServicesTitle_mandatory">';
                    html += '<div class="tarteaucitronTitle">';
-                   html += '   <button type="button" tabindex="-1"><span class="tarteaucitronPlus" aria-hidden="true"></span> ' + tarteaucitron.lang.mandatoryTitle + '</button>';
+                    if(tarteaucitron.parameters.showDetailsOnClick){
+                        html += '   <button type="button" tabindex="-1"><span class="tarteaucitronPlus" aria-hidden="true"></span> ' + tarteaucitron.lang.mandatoryTitle + '</button>';
+                    }else{
+                        html += '   <span>' + tarteaucitron.lang.mandatoryTitle + '</span>';
+                    }
                    html += '</div>';
                    html += '<ul id="tarteaucitronServices_mandatory">';
                    html += '<li class="tarteaucitronLine">';

--- a/tarteaucitron.js
+++ b/tarteaucitron.js
@@ -209,6 +209,7 @@ var tarteaucitron = {
                 "bodyPosition": "bottom",
                 "removeCredit": false,
                 "showAlertSmall": false,
+                "showDetailsOnClick": true,
                 "showIcon": true,
                 "iconPosition": "BottomRight",
                 "cookieslist": false,
@@ -383,9 +384,14 @@ var tarteaucitron = {
                 for (i = 0; i < cat.length; i += 1) {
                     html += '         <li id="tarteaucitronServicesTitle_' + cat[i] + '" class="tarteaucitronHidden">';
                     html += '            <div class="tarteaucitronTitle" role="heading" aria-level="2">';
-                    html += '               <button type="button" class="catToggleBtn" aria-expanded="false" data-cat="tarteaucitronDetails' + cat[i] + '"><span class="tarteaucitronPlus" aria-hidden="true"></span> ' + tarteaucitron.lang[cat[i]].title + '</button>';
+                    if(tarteaucitron.parameters.showDetailsOnClick)
+                    {
+                        html += '               <button type="button" class="catToggleBtn" aria-expanded="false" data-cat="tarteaucitronDetails' + cat[i] + '"><span class="tarteaucitronPlus" aria-hidden="true"></span> ' + tarteaucitron.lang[cat[i]].title + '</button>';
+                    }else{
+                        html += '               <span class="asCatToggleBtn" data-cat="tarteaucitronInlineDetails' + cat[i] + '">' + tarteaucitron.lang[cat[i]].title + '</span>';
+                    }
                     html += '            </div>';
-                    html += '            <div id="tarteaucitronDetails' + cat[i] + '" class="tarteaucitronDetails tarteaucitronInfoBox">';
+                    html += '            <div id="tarteaucitronDetails' + cat[i] + '" class="tarteaucitronDetails '+ (tarteaucitron.parameters.showDetailsOnClick ? 'tarteaucitronInfoBox' : 'tarteaucitronDetailsInline')+'">';
                     html += '               ' + tarteaucitron.lang[cat[i]].details;
                     html += '            </div>';
                     html += '         <ul id="tarteaucitronServices_' + cat[i] + '"></ul></li>';
@@ -752,6 +758,7 @@ var tarteaucitron = {
                     for (i = 0; i < toggleBtns.length; i++) {
                         toggleBtns[i].dataset.index = i;
                         tarteaucitron.addClickEventToElement(toggleBtns[i], function () {
+                            if(!tarteaucitron.parameters.showDetailsOnClick) return false;
                             tarteaucitron.userInterface.toggle('tarteaucitronDetails' + cat[this.dataset.index], 'tarteaucitronInfoBox');
                             if (document.getElementById('tarteaucitronDetails' + cat[this.dataset.index]).style.display === 'block') {
                                 this.setAttribute('aria-expanded', 'true');


### PR DESCRIPTION
Hello,
Several of our customers have received a notification from the CNIL indicating that the descriptive text of the cookies was not directly visible and that clicking on the title of the section ("APIs", "Audience measurement", "Video", etc...) was not intuitive enough for the Internet user to be correctly informed of the operation of each cookie.

We have therefore added an option in the configuration to switch from displaying the description on click to displaying the text directly. This option is deactivated by default, to avoid backward compatibility problems.
To change mode, change the value of the `showDetailsOnClick` attribute to `false`.

---

Version française:
Plusieurs de nos clients ont reçus une notification de la CNIL indiquant que le texte descriptif des cookies n'était pas visible directement et que le clic sur le titre de la section ("APIs", "Mesure d'audience", "Vidéo",etc...) n'était pas assez intuitif pour que l'internaute soit correctement informé du fonctionnement de chaque cookie.

Nous avons donc ajouté une option dans la configuration permettant de passer de l'affichage de la description au clic par un affichage direct du texte. Cette option est désactivée par défaut, évitant les problèmes de rétrocompatibilité.
Pour changer de mode, changer la valeur de l'attribut `showDetailsOnClick` à `false`

