### PR TITLE
XSS fix: use tarteaucitron.getElemAttr method everywhere

### DIFF
--- a/tarteaucitron.services.js
+++ b/tarteaucitron.services.js
@@ -13,7 +13,7 @@ tarteaucitron.services.iframe = {
     "js": function () {
         "use strict";
         tarteaucitron.fallback(['tac_iframe'], function (x) {
-            var frame_title = (tarteaucitron.getElemAttr(x,"title")) ? tarteaucitron.fixSelfXSS(tarteaucitron.getElemAttr(x,"title")) : '',
+            var frame_title = (tarteaucitron.getElemAttr(x,"title")) ? tarteaucitron.getElemAttr(x,"title") : '',
                 width = tarteaucitron.getElemAttr(x,"width"),
                 height = tarteaucitron.getElemAttr(x,"height"),
                 allowfullscreen = tarteaucitron.getElemAttr(x,"allowfullscreen"),
@@ -102,10 +102,10 @@ tarteaucitron.services.twitch = {
     "js": function () {
         "use strict";
         tarteaucitron.fallback(['twitch_player'], function (x) {
-            var id = x.getAttribute('videoID'),
-                parent = x.getAttribute('parent'),
-                width = x.getAttribute('width'),
-                height = x.getAttribute('height');
+            var id = tarteaucitron.getElemAttr(x, 'videoID'),
+                parent = tarteaucitron.getElemAttr(x, 'parent'),
+                width = tarteaucitron.getElemAttr(x, 'width'),
+                height = tarteaucitron.getElemAttr(x, 'height');
             var embedURL = "https://player.twitch.tv/?video=" + id + "&parent=" + parent;
             return "<iframe width=\"" + width + "\" height=\"" + height + "\" src=\"" + embedURL + "\" scrolling=\"no\" frameborder=\"0\"></iframe>";
         });
@@ -603,7 +603,7 @@ tarteaucitron.services.kwanko = {
     "js": function () {
         "use strict";
         tarteaucitron.fallback(['tac_kwanko'], function (x) {
-            var mclic = x.getAttribute("data-mclic");
+            var mclic = tarteaucitron.getElemAttr(x, "data-mclic");
 
             return '<img src="https://action.metaffiliation.com/trk.php?mclic=' + mclic + '" width="1" height="1" border="0" />';
         });
@@ -815,11 +815,11 @@ tarteaucitron.services.videas = {
     "js": function () {
         "use strict";
         tarteaucitron.fallback(['tac_videas'], function (x) {
-            var frame_title = tarteaucitron.fixSelfXSS(x.getAttribute("title") || 'Videas iframe'),
-                width = x.getAttribute("width"),
-                height = x.getAttribute("height"),
-                id = x.getAttribute("data-id"),
-                allowfullscreen = x.getAttribute("allowfullscreen");
+            var frame_title = tarteaucitron.getElemAttr(x, "title") || 'Videas iframe',
+                width = tarteaucitron.getElemAttr(x, "width"),
+                height = tarteaucitron.getElemAttr(x, "height"),
+                id = tarteaucitron.getElemAttr(x, "data-id"),
+                allowfullscreen = tarteaucitron.getElemAttr(x, "allowfullscreen");
 
             return '<iframe title="' + frame_title + '" src="https://app.videas.fr/embed/' + id + '/" width="' + width + '" height="' + height + '" allowtransparency ' + (allowfullscreen == '0' ? '' : ' webkitallowfullscreen mozallowfullscreen allowfullscreen') + '></iframe>';
         });
@@ -1202,7 +1202,7 @@ tarteaucitron.services.xandrsegment = {
         tarteaucitron.fallback(['xandrsegment-canvas'], function (x) {
             var uniqId = '_' + Math.random().toString(36).substr(2, 9);
             uniqIds.push(uniqId);
-            return '<div id="' + uniqId + '" xandrsegmentAdd="' + x.getAttribute('xandrsegmentAdd') + '" xandrsegmentAddCode="' + x.getAttribute('xandrsegmentAddCode') + '" xandrsegmentRemove="' + x.getAttribute('xandrsegmentRemove') + '" xandrsegmentRemoveCode="' + x.getAttribute('xandrsegmentRemoveCode') + '" xandrsegmentMember="' + x.getAttribute('xandrsegmentMember') + '" xandrsegmentRedir="' + x.getAttribute('xandrsegmentRedir') + '" xandrsegmentValue="' + x.getAttribute('xandrsegmentValue') + '" xandrsegmentOther="' + x.getAttribute('xandrsegmentOther') + '"></div>';
+            return '<div id="' + uniqId + '" xandrsegmentAdd="' + tarteaucitron.getElemAttr(x, 'xandrsegmentAdd') + '" xandrsegmentAddCode="' + tarteaucitron.getElemAttr(x, 'xandrsegmentAddCode') + '" xandrsegmentRemove="' + tarteaucitron.getElemAttr(x, 'xandrsegmentRemove') + '" xandrsegmentRemoveCode="' + tarteaucitron.getElemAttr(x, 'xandrsegmentRemoveCode') + '" xandrsegmentMember="' + tarteaucitron.getElemAttr(x, 'xandrsegmentMember') + '" xandrsegmentRedir="' + tarteaucitron.getElemAttr(x, 'xandrsegmentRedir') + '" xandrsegmentValue="' + tarteaucitron.getElemAttr(x, 'xandrsegmentValue') + '" xandrsegmentOther="' + tarteaucitron.getElemAttr(x, 'xandrsegmentOther') + '"></div>';
         });
 
         for (i = 0; i < uniqIds.length; i += 1) {
@@ -1244,7 +1244,7 @@ tarteaucitron.services.xandrconversion = {
         tarteaucitron.fallback(['xandrconversion-canvas'], function (x) {
             var uniqId = '_' + Math.random().toString(36).substr(2, 9);
             uniqIds.push(uniqId);
-            return '<div id="' + uniqId + '" xandrconversionId="' + x.getAttribute('xandrconversionId') + '" xandrconversionSeg="' + x.getAttribute('xandrconversionSeg') + '" xandrconversionOrderId="' + x.getAttribute('xandrconversionOrderId') + '" xandrconversionValue="' + x.getAttribute('xandrconversionValue') + '" xandrconversionRedir="' + x.getAttribute('xandrconversionRedir') + '" xandrconversionOther="' + x.getAttribute('xandrconversionOther') + '"></div>';
+            return '<div id="' + uniqId + '" xandrconversionId="' + tarteaucitron.getElemAttr(x, 'xandrconversionId') + '" xandrconversionSeg="' + tarteaucitron.getElemAttr(x, 'xandrconversionSeg') + '" xandrconversionOrderId="' + tarteaucitron.getElemAttr(x, 'xandrconversionOrderId') + '" xandrconversionValue="' + tarteaucitron.getElemAttr(x, 'xandrconversionValue') + '" xandrconversionRedir="' + tarteaucitron.getElemAttr(x, 'xandrconversionRedir') + '" xandrconversionOther="' + tarteaucitron.getElemAttr(x, 'xandrconversionOther') + '"></div>';
         });
 
         for (i = 0; i < uniqIds.length; i += 1) {
@@ -1277,11 +1277,11 @@ tarteaucitron.services.helloasso = {
     "js": function () {
         "use strict";
         tarteaucitron.fallback(['tac_helloasso'], function (x) {
-            var frame_title = tarteaucitron.fixSelfXSS(x.getAttribute("title") || 'HelloAsso iframe'),
-                width = x.getAttribute("width"),
-                height = x.getAttribute("height"),
-                url = x.getAttribute("data-url"),
-                allowfullscreen = x.getAttribute("allowfullscreen");
+            var frame_title = tarteaucitron.getElemAttr(x, "title") || 'HelloAsso iframe',
+                width = tarteaucitron.getElemAttr(x, "width"),
+                height = tarteaucitron.getElemAttr(x, "height"),
+                url = tarteaucitron.getElemAttr(x, "data-url"),
+                allowfullscreen = tarteaucitron.getElemAttr(x, "allowfullscreen");
 
             return '<iframe title="' + frame_title + '" id="haWidget" src="' + url + '" width="' + width + '" height="' + height + '" scrolling="auto" allowtransparency ' + (allowfullscreen == '0' ? '' : ' webkitallowfullscreen mozallowfullscreen allowfullscreen') + '></iframe>';
         });
@@ -1308,11 +1308,11 @@ tarteaucitron.services.podcloud = {
     "js": function () {
         "use strict";
         tarteaucitron.fallback(['tac_podcloud'], function (x) {
-            var frame_title = tarteaucitron.fixSelfXSS(x.getAttribute("title") || 'podCloud iframe'),
-                width = x.getAttribute("width"),
-                height = x.getAttribute("height"),
-                url = x.getAttribute("data-url"),
-                allowfullscreen = x.getAttribute("allowfullscreen");
+            var frame_title = tarteaucitron.getElemAttr(x, "title") || 'podCloud iframe',
+                width = tarteaucitron.getElemAttr(x, "width"),
+                height = tarteaucitron.getElemAttr(x, "height"),
+                url = tarteaucitron.getElemAttr(x, "data-url"),
+                allowfullscreen = tarteaucitron.getElemAttr(x, "allowfullscreen");
 
             return '<iframe title="' + frame_title + '" src="' + url + '" width="' + width + '" height="' + height + '" scrolling="auto" allowtransparency ' + (allowfullscreen == '0' ? '' : ' webkitallowfullscreen mozallowfullscreen allowfullscreen') + '></iframe>';
         });
@@ -1339,13 +1339,13 @@ tarteaucitron.services.facebookpost = {
     "js": function () {
         "use strict";
         tarteaucitron.fallback(['tac_facebookpost'], function (x) {
-            var frame_title = tarteaucitron.fixSelfXSS(x.getAttribute("title") || 'Facebook iframe'),
-                width = x.getAttribute("width"),
-                height = x.getAttribute("height"),
-                url = x.getAttribute("data-url"),
-                appId = x.getAttribute("data-appid"),
-                allowfullscreen = x.getAttribute("allowfullscreen"),
-                showText = x.getAttribute("data-show-text");
+            var frame_title = tarteaucitron.getElemAttr(x, "title") || 'Facebook iframe',
+                width = tarteaucitron.getElemAttr(x, "width"),
+                height = tarteaucitron.getElemAttr(x, "height"),
+                url = tarteaucitron.getElemAttr(x, "data-url"),
+                appId = tarteaucitron.getElemAttr(x, "data-appid"),
+                allowfullscreen = tarteaucitron.getElemAttr(x, "allowfullscreen"),
+                showText = tarteaucitron.getElemAttr(x, "data-show-text");
 
             return '<iframe title="' + frame_title + '" src="https://www.facebook.com/plugins/post.php?href=' + encodeURIComponent(url) + '&amp;width=' + width + '&amp;show_text=false&amp;appId=' + appId + '&amp;show_text=' + showText + '&amp;height=' + height + '" width="' + width + '" height="' + height + '" scrolling="auto" allowtransparency ' + (allowfullscreen == '0' ? '' : ' webkitallowfullscreen mozallowfullscreen allowfullscreen') + '></iframe>';
         });
@@ -1753,9 +1753,9 @@ tarteaucitron.services.amazon = {
     "js": function () {
         "use strict";
         tarteaucitron.fallback(['amazon_product'], function (x) {
-            var frame_title = tarteaucitron.fixSelfXSS(x.getAttribute("title") || 'Amazon iframe'),
-                amazonId = x.getAttribute("amazonid"),
-                productId = x.getAttribute("productid"),
+            var frame_title = tarteaucitron.getElemAttr(x, "title") || 'Amazon iframe',
+                amazonId = tarteaucitron.getElemAttr(x, "amazonid"),
+                productId = tarteaucitron.getElemAttr(x, "productid"),
                 url = '//ws-eu.amazon-adsystem.com/widgets/q?ServiceVersion=20070822&OneJS=1&Operation=GetAdHtml&MarketPlace=' + tarteaucitron.getLanguage().toUpperCase() + '&source=ss&ref=ss_til&ad_type=product_link&tracking_id=' + amazonId + '&marketplace=amazon&region=' + tarteaucitron.getLanguage().toUpperCase() + '&placement=' + productId + '&asins=' + productId + '&show_border=true&link_opens_in_new_window=true',
                 iframe = '<iframe title="' + frame_title + '" style="width:120px;height:240px;" marginwidth="0" marginheight="0" scrolling="no" src="' + url + '"></iframe>';
 
@@ -1780,12 +1780,12 @@ tarteaucitron.services.calameo = {
     "js": function () {
         "use strict";
         tarteaucitron.fallback(['calameo-canvas'], function (x) {
-            var frame_title = tarteaucitron.fixSelfXSS(x.getAttribute("title") || 'Calameo iframe'),
-                id = x.getAttribute("data-id"),
-                width = x.getAttribute("width"),
-                height = x.getAttribute("height"),
+            var frame_title = tarteaucitron.getElemAttr(x, "title") || 'Calameo iframe',
+                id = tarteaucitron.getElemAttr(x, "data-id"),
+                width = tarteaucitron.getElemAttr(x, "width"),
+                height = tarteaucitron.getElemAttr(x, "height"),
                 url = '//v.calameo.com/?bkcode=' + id,
-                allowfullscreen = x.getAttribute("allowfullscreen");
+                allowfullscreen = tarteaucitron.getElemAttr(x, "allowfullscreen");
 
             return '<iframe title="' + frame_title + '" src="' + url + '" width="' + width + '" height="' + height + '" scrolling="no" allowtransparency ' + (allowfullscreen == '0' ? '' : ' webkitallowfullscreen mozallowfullscreen allowfullscreen') + '></iframe>';
         });
@@ -1842,7 +1842,7 @@ tarteaucitron.services.clicmanager = {
         tarteaucitron.fallback(['clicmanager-canvas'], function (x) {
             var uniqId = '_' + Math.random().toString(36).substr(2, 9);
             uniqIds.push(uniqId);
-            return '<div id="' + uniqId + '" c="' + x.getAttribute('c') + '" s="' + x.getAttribute('s') + '" t="' + x.getAttribute('t') + '"></div>';
+            return '<div id="' + uniqId + '" c="' + tarteaucitron.getElemAttr(x, 'c') + '" s="' + tarteaucitron.getElemAttr(x, 's') + '" t="' + tarteaucitron.getElemAttr(x, 't') + '"></div>';
         });
 
         for (i = 0; i < uniqIds.length; i += 1) {
@@ -1949,7 +1949,7 @@ tarteaucitron.services.criteo = {
         tarteaucitron.fallback(['criteo-canvas'], function (x) {
             var uniqId = '_' + Math.random().toString(36).substr(2, 9);
             uniqIds.push(uniqId);
-            return '<div id="' + uniqId + '" zoneid="' + x.getAttribute('zoneid') + '"></div>';
+            return '<div id="' + uniqId + '" zoneid="' + tarteaucitron.getElemAttr(x, 'zoneid') + '"></div>';
         });
 
         for (i = 0; i < uniqIds.length; i += 1) {
@@ -2012,12 +2012,12 @@ tarteaucitron.services.artetv = {
     "js": function () {
         "use strict";
         tarteaucitron.fallback(['artetv_player'], function (x) {
-            var frame_title = tarteaucitron.fixSelfXSS(x.getAttribute("title") || 'Arte.tv iframe'),
-                video_json = x.getAttribute("json"),
-                video_width = x.getAttribute("width"),
-                video_height = x.getAttribute("height"),
+            var frame_title = tarteaucitron.getElemAttr(x, "title") || 'Arte.tv iframe',
+                video_json = tarteaucitron.getElemAttr(x, "json"),
+                video_width = tarteaucitron.getElemAttr(x, "width"),
+                video_height = tarteaucitron.getElemAttr(x, "height"),
                 video_frame,
-                video_allowfullscreen = x.getAttribute("allowfullscreen");
+                video_allowfullscreen = tarteaucitron.getElemAttr(x, "allowfullscreen");
 
             if (video_json === undefined) {
                 return "";
@@ -2049,7 +2049,7 @@ tarteaucitron.services.dailymotion = {
     "js": function () {
         "use strict";
         tarteaucitron.fallback(['dailymotion_player'], function (x) {
-            var frame_title = tarteaucitron.fixSelfXSS(tarteaucitron.getElemAttr(x, "title") || 'Dailymotion iframe'),
+            var frame_title = tarteaucitron.getElemAttr(x, "title") || 'Dailymotion iframe',
                 video_id = tarteaucitron.getElemAttr(x, "videoID"),
                 video_width = tarteaucitron.getElemAttr(x, "width"),
                 frame_width = 'width=',
@@ -2105,17 +2105,17 @@ tarteaucitron.services.datingaffiliation = {
     "js": function () {
         "use strict";
         tarteaucitron.fallback(['datingaffiliation-canvas'], function (x) {
-            var frame_title = tarteaucitron.fixSelfXSS(x.getAttribute("title") || 'Dating Affiliation iframe'),
-                comfrom = x.getAttribute("data-comfrom"),
-                r = x.getAttribute("data-r"),
-                p = x.getAttribute("data-p"),
-                cf0 = x.getAttribute("data-cf0"),
-                langue = x.getAttribute("data-langue"),
-                forward_affiliate = x.getAttribute("data-forwardAffiliate"),
-                cf2 = x.getAttribute("data-cf2"),
-                cfsa2 = x.getAttribute("data-cfsa2"),
-                width = x.getAttribute("width"),
-                height = x.getAttribute("height"),
+            var frame_title = tarteaucitron.getElemAttr(x, "title") || 'Dating Affiliation iframe',
+                comfrom = tarteaucitron.getElemAttr(x, "data-comfrom"),
+                r = tarteaucitron.getElemAttr(x, "data-r"),
+                p = tarteaucitron.getElemAttr(x, "data-p"),
+                cf0 = tarteaucitron.getElemAttr(x, "data-cf0"),
+                langue = tarteaucitron.getElemAttr(x, "data-langue"),
+                forward_affiliate = tarteaucitron.getElemAttr(x, "data-forwardAffiliate"),
+                cf2 = tarteaucitron.getElemAttr(x, "data-cf2"),
+                cfsa2 = tarteaucitron.getElemAttr(x, "data-cfsa2"),
+                width = tarteaucitron.getElemAttr(x, "width"),
+                height = tarteaucitron.getElemAttr(x, "height"),
                 url = 'http://www.tools-affil2.com/rotaban/ban.php?' + comfrom;
 
             return '<iframe title="' + frame_title + '" src="' + url + '&r=' + r + '&p=' + p + '&cf0=' + cf0 + '&langue=' + langue + '&forward_affiliate=' + forward_affiliate + '&cf2=' + cf2 + '&cfsa2=' + cfsa2 + '" width="' + width + '" height="' + height + '" marginheight="0" marginwidth="0" scrolling="no"></iframe>';
@@ -2149,7 +2149,7 @@ tarteaucitron.services.datingaffiliationpopup = {
         tarteaucitron.fallback(['datingaffiliationpopup-canvas'], function (x) {
             var uniqId = '_' + Math.random().toString(36).substr(2, 9);
             uniqIds.push(uniqId);
-            return '<div id="' + uniqId + '" uri="' + x.getAttribute('uri') + '" comfrom="' + x.getAttribute('comfrom') + '" promo="' + x.getAttribute('promo') + '" productid="' + x.getAttribute('productid') + '" submitconfig="' + x.getAttribute('submitconfig') + '" ur="' + x.getAttribute('ur') + '" brand="' + x.getAttribute('brand') + '" lang="' + x.getAttribute('lang') + '" cf0="' + x.getAttribute('cf0') + '" cf2="' + x.getAttribute('cf2') + '" subid1="' + x.getAttribute('subid1') + '" cfsa2="' + x.getAttribute('cfsa2') + '" subid2="' + x.getAttribute('subid2') + '" nicheid="' + x.getAttribute('nicheid') + '" degreid="' + x.getAttribute('degreid') + '" bt="' + x.getAttribute('bt') + '" vis="' + x.getAttribute('vis') + '" hid="' + x.getAttribute('hid') + '" snd="' + x.getAttribute('snd') + '" aabd="' + x.getAttribute('aabd') + '" aabs="' + x.getAttribute('aabs') + '"></div>';
+            return '<div id="' + uniqId + '" uri="' + tarteaucitron.getElemAttr(x, 'uri') + '" comfrom="' + tarteaucitron.getElemAttr(x, 'comfrom') + '" promo="' + tarteaucitron.getElemAttr(x, 'promo') + '" productid="' + tarteaucitron.getElemAttr(x, 'productid') + '" submitconfig="' + tarteaucitron.getElemAttr(x, 'submitconfig') + '" ur="' + tarteaucitron.getElemAttr(x, 'ur') + '" brand="' + tarteaucitron.getElemAttr(x, 'brand') + '" lang="' + tarteaucitron.getElemAttr(x, 'lang') + '" cf0="' + tarteaucitron.getElemAttr(x, 'cf0') + '" cf2="' + tarteaucitron.getElemAttr(x, 'cf2') + '" subid1="' + tarteaucitron.getElemAttr(x, 'subid1') + '" cfsa2="' + tarteaucitron.getElemAttr(x, 'cfsa2') + '" subid2="' + tarteaucitron.getElemAttr(x, 'subid2') + '" nicheid="' + tarteaucitron.getElemAttr(x, 'nicheid') + '" degreid="' + tarteaucitron.getElemAttr(x, 'degreid') + '" bt="' + tarteaucitron.getElemAttr(x, 'bt') + '" vis="' + tarteaucitron.getElemAttr(x, 'vis') + '" hid="' + tarteaucitron.getElemAttr(x, 'hid') + '" snd="' + tarteaucitron.getElemAttr(x, 'snd') + '" aabd="' + tarteaucitron.getElemAttr(x, 'aabd') + '" aabs="' + tarteaucitron.getElemAttr(x, 'aabs') + '"></div>';
         });
 
         for (i = 0; i < uniqIds.length; i += 1) {
@@ -2196,18 +2196,18 @@ tarteaucitron.services.deezer = {
     "js": function () {
         "use strict";
         tarteaucitron.fallback(['deezer_player'], function (x) {
-            var frame_title = tarteaucitron.fixSelfXSS(x.getAttribute("title") || 'Deezer iframe'),
-                deezer_id = x.getAttribute("deezerID"),
-                deezer_width = x.getAttribute("width"),
+            var frame_title = tarteaucitron.getElemAttr(x, "title") || 'Deezer iframe',
+                deezer_id = tarteaucitron.getElemAttr(x, "deezerID"),
+                deezer_width = tarteaucitron.getElemAttr(x, "width"),
                 frame_width = 'width=',
-                deezer_height = x.getAttribute("height"),
+                deezer_height = tarteaucitron.getElemAttr(x, "height"),
                 frame_height = 'height=',
                 deezer_frame,
-                embed_theme = x.getAttribute("theme"),
-                embed_type = x.getAttribute("embedType"),
-                radius = x.getAttribute("radius"),
-                tracklist = x.getAttribute("tracklist"),
-                allowfullscreen = x.getAttribute("allowfullscreen"),
+                embed_theme = tarteaucitron.getElemAttr(x, "theme"),
+                embed_type = tarteaucitron.getElemAttr(x, "embedType"),
+                radius = tarteaucitron.getElemAttr(x, "radius"),
+                tracklist = tarteaucitron.getElemAttr(x, "tracklist"),
+                allowfullscreen = tarteaucitron.getElemAttr(x, "allowfullscreen"),
                 params;
 
             if (deezer_id === undefined) {
@@ -2986,11 +2986,11 @@ tarteaucitron.services.genially = {
         "use strict";
 
         tarteaucitron.fallback(['tac_genially'], function (x) {
-            var frame_title = tarteaucitron.fixSelfXSS(x.getAttribute("title") || 'genially iframe'),
-                width = x.getAttribute("width"),
-                height = x.getAttribute("height"),
-                geniallyid = x.getAttribute("geniallyid"),
-                allowfullscreen = x.getAttribute("allowfullscreen");
+            var frame_title = tarteaucitron.getElemAttr(x, "title") || 'genially iframe',
+                width = tarteaucitron.getElemAttr(x, "width"),
+                height = tarteaucitron.getElemAttr(x, "height"),
+                geniallyid = tarteaucitron.getElemAttr(x, "geniallyid"),
+                allowfullscreen = tarteaucitron.getElemAttr(x, "allowfullscreen");
 
             return '<div style="position: relative; padding-bottom: 109.00%; padding-top: 0; height: 0;"><iframe style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;" title="' + frame_title + '" src="https://view.genial.ly/' + geniallyid + '" width="' + width + '" height="' + height + '" scrolling="auto" allowtransparency ' + (allowfullscreen == '0' ? '' : ' webkitallowfullscreen mozallowfullscreen allowfullscreen') + '></iframe></div>';
         });
@@ -3037,7 +3037,7 @@ tarteaucitron.services.googlemaps = {
             tarteaucitron.fallback(['googlemaps-canvas'], function (x) {
                 var uniqId = '_' + Math.random().toString(36).substr(2, 9);
                 uniqIds.push(uniqId);
-                return '<div id="' + uniqId + '" zoom="' + x.getAttribute('zoom') + '" latitude="' + x.getAttribute('latitude') + '" longitude="' + x.getAttribute('longitude') + '" style="width:' + x.offsetWidth + 'px;height:' + x.offsetHeight + 'px"></div>';
+                return '<div id="' + uniqId + '" zoom="' + tarteaucitron.getElemAttr(x, 'zoom') + '" latitude="' + tarteaucitron.getElemAttr(x, 'latitude') + '" longitude="' + tarteaucitron.getElemAttr(x, 'longitude') + '" style="width:' + x.offsetWidth + 'px;height:' + x.offsetHeight + 'px"></div>';
             });
 
             var i;
@@ -3069,12 +3069,12 @@ tarteaucitron.services.googlemapssearch = {
     "js": function () {
         "use strict";
         tarteaucitron.fallback(['googlemapssearch'], function (x) {
-            var frame_title = tarteaucitron.fixSelfXSS(x.getAttribute("title") || 'Google search iframe'),
-                width = x.getAttribute("width"),
-                height = x.getAttribute("height"),
-                // url = x.getAttribute("data-url");
-                query = escape(x.getAttribute("data-search")),
-                key = x.getAttribute("data-api-key");
+            var frame_title = tarteaucitron.getElemAttr(x, "title") || 'Google search iframe',
+                width = tarteaucitron.getElemAttr(x, "width"),
+                height = tarteaucitron.getElemAttr(x, "height"),
+                // url = tarteaucitron.getElemAttr(x, "data-url");
+                query = escape(tarteaucitron.getElemAttr(x, "data-search")),
+                key = tarteaucitron.getElemAttr(x, "data-api-key");
 
             return '<iframe title="' + frame_title + '" width="' + width + '" height="' + height + '" style="border:0" src="https://www.google.com/maps/embed/v1/place?q=' + query + '&key=' + key + '" allowfullscreen></iframe> '
         });
@@ -3101,10 +3101,10 @@ tarteaucitron.services.googlemapsembed = {
     "js": function () {
         "use strict";
         tarteaucitron.fallback(['googlemapsembed'], function (x) {
-            var frame_title = tarteaucitron.fixSelfXSS(x.getAttribute("title") || 'Google maps iframe'),
+            var frame_title = tarteaucitron.getElemAttr(x, "title") || 'Google maps iframe',
                 width = tarteaucitron.getElemWidth(x),
                 height = tarteaucitron.getElemHeight(x),
-                url = x.getAttribute("data-url");
+                url = tarteaucitron.getElemAttr(x, "data-url");
 
             return '<iframe title="' + frame_title + '" src="' + url + '" width="' + width + '" height="' + height + '" scrolling="no" allowtransparency allowfullscreen></iframe>';
         });
@@ -3134,7 +3134,7 @@ tarteaucitron.services.openstreetmap = {
         tarteaucitron.fallback(['openstreetmap'], function (x) {
             var width = tarteaucitron.getElemWidth(x),
                 height = tarteaucitron.getElemHeight(x),
-                url = x.getAttribute("data-url");
+                url = tarteaucitron.getElemAttr(x, "data-url");
 
             return '<iframe src="' + url + '" width="' + width + '" height="' + height + '" frameborder="0" scrolling="no" marginheight="0" marginwidth="0" allowfullscreen></iframe>';
         });
@@ -3163,7 +3163,7 @@ tarteaucitron.services.geoportail = {
         tarteaucitron.fallback(['geoportail'], function (x) {
             var width = tarteaucitron.getElemWidth(x),
                 height = tarteaucitron.getElemHeight(x),
-                url = x.getAttribute("data-url");
+                url = tarteaucitron.getElemAttr(x, "data-url");
 
             return '<iframe src="' + url + '" width="' + width + '" height="' + height + '" frameborder="0" scrolling="no" marginheight="0" marginwidth="0" sandbox="allow-forms allow-scripts allow-same-origin" allowfullscreen></iframe>';
         });
@@ -3285,11 +3285,11 @@ tarteaucitron.services.instagram = {
     "js": function () {
         "use strict";
         tarteaucitron.fallback(['instagram_post'], function (x) {
-            var frame_title = tarteaucitron.fixSelfXSS(x.getAttribute("title") || 'Instagram iframe'),
-                post_id = x.getAttribute('postId'),
-                post_permalink = x.getAttribute('data-instgrm-permalink'),
-                embed_width = x.getAttribute('width'),
-                embed_height = x.getAttribute('height'),
+            var frame_title = tarteaucitron.getElemAttr(x, "title") || 'Instagram iframe',
+                post_id = tarteaucitron.getElemAttr(x, 'postId'),
+                post_permalink = tarteaucitron.getElemAttr(x, 'data-instgrm-permalink'),
+                embed_width = tarteaucitron.getElemAttr(x, 'width'),
+                embed_height = tarteaucitron.getElemAttr(x, 'height'),
                 frame_width,
                 frame_height,
                 post_frame;
@@ -3528,7 +3528,7 @@ tarteaucitron.services.prelinker = {
         tarteaucitron.fallback(['prelinker-canvas'], function (x) {
             var uniqId = '_' + Math.random().toString(36).substr(2, 9);
             uniqIds.push(uniqId);
-            return '<div id="' + uniqId + '" siteId="' + x.getAttribute('siteId') + '" bannerId="' + x.getAttribute('bannerId') + '" defaultLanguage="' + x.getAttribute('defaultLanguage') + '" tracker="' + x.getAttribute('tracker') + '"></div>';
+            return '<div id="' + uniqId + '" siteId="' + tarteaucitron.getElemAttr(x, 'siteId') + '" bannerId="' + tarteaucitron.getElemAttr(x, 'bannerId') + '" defaultLanguage="' + tarteaucitron.getElemAttr(x, 'defaultLanguage') + '" tracker="' + tarteaucitron.getElemAttr(x, 'tracker') + '"></div>';
         });
 
         for (i = 0; i < uniqIds.length; i += 1) {
@@ -3559,10 +3559,10 @@ tarteaucitron.services.prezi = {
     "js": function () {
         "use strict";
         tarteaucitron.fallback(['prezi-canvas'], function (x) {
-            var frame_title = tarteaucitron.fixSelfXSS(x.getAttribute("title") || 'Prezi iframe'),
-                id = x.getAttribute("data-id"),
-                width = x.getAttribute("width"),
-                height = x.getAttribute("height"),
+            var frame_title = tarteaucitron.getElemAttr(x, "title") || 'Prezi iframe',
+                id = tarteaucitron.getElemAttr(x, "data-id"),
+                width = tarteaucitron.getElemAttr(x, "width"),
+                height = tarteaucitron.getElemAttr(x, "height"),
                 url = 'https://prezi.com/embed/' + id + '/?bgcolor=ffffff&amp;lock_to_path=0&amp;autoplay=0&amp;autohide_ctrls=0';
 
             return '<iframe title="' + frame_title + '" src="' + url + '" width="' + width + '" height="' + height + '" scrolling="no" allowtransparency allowfullscreen></iframe>';
@@ -3596,7 +3596,7 @@ tarteaucitron.services.pubdirecte = {
         tarteaucitron.fallback(['pubdirecte-canvas'], function (x) {
             var uniqId = '_' + Math.random().toString(36).substr(2, 9);
             uniqIds.push(uniqId);
-            return '<div id="' + uniqId + '" pid="' + x.getAttribute('pid') + '" ref="' + x.getAttribute('ref') + '"></div>';
+            return '<div id="' + uniqId + '" pid="' + tarteaucitron.getElemAttr(x, 'pid') + '" ref="' + tarteaucitron.getElemAttr(x, 'ref') + '"></div>';
         });
 
         for (i = 0; i < uniqIds.length; i += 1) {
@@ -3715,7 +3715,7 @@ tarteaucitron.services.rumbletalk = {
         tarteaucitron.fallback(['rumbletalk'], function (x) {
             var width = tarteaucitron.getElemWidth(x),
                 height = tarteaucitron.getElemHeight(x),
-                id = x.getAttribute("data-id");
+                id = tarteaucitron.getElemAttr(x, "data-id");
 
             return '<div style="height: ' + height + 'px; width: ' + width + 'px;"><div id="' + id + '"></div></div>';
         });
@@ -3777,7 +3777,7 @@ tarteaucitron.services.shareasale = {
         tarteaucitron.fallback(['shareasale-canvas'], function (x) {
             var uniqId = '_' + Math.random().toString(36).substr(2, 9);
             uniqIds.push(uniqId);
-            return '<div id="' + uniqId + '" amount="' + x.getAttribute('amount') + '" tracking="' + x.getAttribute('tracking') + '" transtype="' + x.getAttribute('transtype') + '" persale="' + x.getAttribute('persale') + '" perlead="' + x.getAttribute('perlead') + '" perhit="' + x.getAttribute('perhit') + '" merchantID="' + x.getAttribute('merchantID') + '"></div>';
+            return '<div id="' + uniqId + '" amount="' + tarteaucitron.getElemAttr(x, 'amount') + '" tracking="' + tarteaucitron.getElemAttr(x, 'tracking') + '" transtype="' + tarteaucitron.getElemAttr(x, 'transtype') + '" persale="' + tarteaucitron.getElemAttr(x, 'persale') + '" perlead="' + tarteaucitron.getElemAttr(x, 'perlead') + '" perhit="' + tarteaucitron.getElemAttr(x, 'perhit') + '" merchantID="' + tarteaucitron.getElemAttr(x, 'merchantID') + '"></div>';
         });
 
         for (i = 0; i < uniqIds.length; i += 1) {
@@ -3845,10 +3845,10 @@ tarteaucitron.services.slideshare = {
     "js": function () {
         "use strict";
         tarteaucitron.fallback(['slideshare-canvas'], function (x) {
-            var frame_title = tarteaucitron.fixSelfXSS(x.getAttribute("title") || 'Slideshare iframe'),
-                id = x.getAttribute("data-id"),
-                width = x.getAttribute("width"),
-                height = x.getAttribute("height"),
+            var frame_title = tarteaucitron.getElemAttr(x, "title") || 'Slideshare iframe',
+                id = tarteaucitron.getElemAttr(x, "data-id"),
+                width = tarteaucitron.getElemAttr(x, "width"),
+                height = tarteaucitron.getElemAttr(x, "height"),
                 url = '//www.slideshare.net/slideshow/embed_code/' + id;
 
             return '<iframe title="' + frame_title + '" src="' + url + '" width="' + width + '" height="' + height + '" scrolling="no" allowtransparency allowfullscreen></iframe>';
@@ -3876,21 +3876,21 @@ tarteaucitron.services.soundcloud = {
     js: function () {
         "use strict";
         tarteaucitron.fallback(['soundcloud_player'], function (x) {
-            var frame_title = tarteaucitron.fixSelfXSS(x.getAttribute("title") || 'Soundcloud iframe'),
-                player_height = x.getAttribute('data-height'),
+            var frame_title = tarteaucitron.getElemAttr(x, "title") || 'Soundcloud iframe',
+                player_height = tarteaucitron.getElemAttr(x, 'data-height'),
                 frame_height = 'height="' + player_height + '" ',
-                playable_id = x.getAttribute('data-playable-id'),
-                playable_type = x.getAttribute('data-playable-type'),
-                playable_url = x.getAttribute('data-playable-url'),
-                color = x.getAttribute('data-color'),
-                autoplay = x.getAttribute('data-auto-play'),
-                hideRelated = x.getAttribute('data-hide-related'),
-                showComments = x.getAttribute('data-show-comments'),
-                showUser = x.getAttribute('data-show-user'),
-                showReposts = x.getAttribute('data-show-reposts'),
-                showTeaser = x.getAttribute('data-show-teaser'),
-                visual = x.getAttribute('data-visual'),
-                artwork = x.getAttribute('data-artwork');
+                playable_id = tarteaucitron.getElemAttr(x, 'data-playable-id'),
+                playable_type = tarteaucitron.getElemAttr(x, 'data-playable-type'),
+                playable_url = tarteaucitron.getElemAttr(x, 'data-playable-url'),
+                color = tarteaucitron.getElemAttr(x, 'data-color'),
+                autoplay = tarteaucitron.getElemAttr(x, 'data-auto-play'),
+                hideRelated = tarteaucitron.getElemAttr(x, 'data-hide-related'),
+                showComments = tarteaucitron.getElemAttr(x, 'data-show-comments'),
+                showUser = tarteaucitron.getElemAttr(x, 'data-show-user'),
+                showReposts = tarteaucitron.getElemAttr(x, 'data-show-reposts'),
+                showTeaser = tarteaucitron.getElemAttr(x, 'data-show-teaser'),
+                visual = tarteaucitron.getElemAttr(x, 'data-visual'),
+                artwork = tarteaucitron.getElemAttr(x, 'data-artwork');
 
             var allowAutoplay = autoplay === 'true' ? 'allow="autoplay"' : '';
 
@@ -3937,11 +3937,11 @@ tarteaucitron.services.spotify = {
     "js": function () {
         "use strict";
         tarteaucitron.fallback(['spotify_player'], function (x) {
-            var frame_title = tarteaucitron.fixSelfXSS(x.getAttribute("title") || 'Spotify iframe'),
-                spotify_id = x.getAttribute("spotifyID"),
-                spotify_width = x.getAttribute("width"),
+            var frame_title = tarteaucitron.getElemAttr(x, "title") || 'Spotify iframe',
+                spotify_id = tarteaucitron.getElemAttr(x, "spotifyID"),
+                spotify_width = tarteaucitron.getElemAttr(x, "width"),
                 frame_width = 'width=',
-                spotify_height = x.getAttribute("height"),
+                spotify_height = tarteaucitron.getElemAttr(x, "height"),
                 frame_height = 'height=',
                 spotify_frame;
 
@@ -4015,17 +4015,17 @@ tarteaucitron.services.timelinejs = {
     "js": function () {
         "use strict";
         tarteaucitron.fallback(['timelinejs-canvas'], function (x) {
-            var frame_title = tarteaucitron.fixSelfXSS(x.getAttribute("title") || 'Twitter iframe'),
-                spreadsheet_id = x.getAttribute("spreadsheet_id"),
-                width = x.getAttribute("width"),
-                height = x.getAttribute("height"),
-                lang = x.getAttribute("lang_2_letter"),
-                font = x.getAttribute("font"),
-                map = x.getAttribute("map"),
-                start_at_end = x.getAttribute("start_at_end"),
-                hash_bookmark = x.getAttribute("hash_bookmark"),
-                start_at_slide = x.getAttribute("start_at_slide"),
-                start_zoom = x.getAttribute("start_zoom"),
+            var frame_title = tarteaucitron.getElemAttr(x, "title") || 'Twitter iframe',
+                spreadsheet_id = tarteaucitron.getElemAttr(x, "spreadsheet_id"),
+                width = tarteaucitron.getElemAttr(x, "width"),
+                height = tarteaucitron.getElemAttr(x, "height"),
+                lang = tarteaucitron.getElemAttr(x, "lang_2_letter"),
+                font = tarteaucitron.getElemAttr(x, "font"),
+                map = tarteaucitron.getElemAttr(x, "map"),
+                start_at_end = tarteaucitron.getElemAttr(x, "start_at_end"),
+                hash_bookmark = tarteaucitron.getElemAttr(x, "hash_bookmark"),
+                start_at_slide = tarteaucitron.getElemAttr(x, "start_at_slide"),
+                start_zoom = tarteaucitron.getElemAttr(x, "start_zoom"),
                 url = '//cdn.knightlab.com/libs/timeline/latest/embed/index.html?source=' + spreadsheet_id + '&font=' + font + '&maptype=' + map + '&lang=' + lang + '&start_at_end=' + start_at_end + '&hash_bookmark=' + hash_bookmark + '&start_at_slide=' + start_at_slide + '&start_zoom_adjust=' + start_zoom + '&height=' + height;
 
             return '<iframe title="' + frame_title + '" src="' + url + '" width="' + width + '" height="' + height + '" allowtransparency allowfullscreen></iframe>';
@@ -4138,12 +4138,12 @@ tarteaucitron.services.twitterembed = {
             var uniqId = '_' + Math.random().toString(36).substr(2, 9);
             uniqIds.push(uniqId);
             html = '<div id="' + uniqId + '" ';
-            html += 'tweetid="' + x.getAttribute('tweetid') + '" ';
-            html += 'theme="' + x.getAttribute('theme') + '" ';
-            html += 'cards="' + x.getAttribute('cards') + '" ';
-            html += 'conversation="' + x.getAttribute('conversation') + '" ';
-            html += 'data-width="' + x.getAttribute('data-width') + '" ';
-            html += 'data-align="' + x.getAttribute('data-align') + '" ';
+            html += 'tweetid="' + tarteaucitron.getElemAttr(x, 'tweetid') + '" ';
+            html += 'theme="' + tarteaucitron.getElemAttr(x, 'theme') + '" ';
+            html += 'cards="' + tarteaucitron.getElemAttr(x, 'cards') + '" ';
+            html += 'conversation="' + tarteaucitron.getElemAttr(x, 'conversation') + '" ';
+            html += 'data-width="' + tarteaucitron.getElemAttr(x, 'data-width') + '" ';
+            html += 'data-align="' + tarteaucitron.getElemAttr(x, 'data-align') + '" ';
             html += '></div>';
             return html;
         });
@@ -4250,7 +4250,7 @@ tarteaucitron.services.vimeo = {
     "js": function () {
         "use strict";
         tarteaucitron.fallback(['vimeo_player'], function (x) {
-            var frame_title = tarteaucitron.fixSelfXSS(tarteaucitron.getElemAttr(x, "title") || 'Vimeo iframe'),
+            var frame_title = tarteaucitron.getElemAttr(x, "title") || 'Vimeo iframe',
                 video_width = tarteaucitron.getElemAttr(x, "width"),
                 frame_width = 'width=',
                 video_height = tarteaucitron.getElemAttr(x, "height"),
@@ -4549,7 +4549,7 @@ tarteaucitron.services.youtube = {
     "js": function () {
         "use strict";
         tarteaucitron.fallback(['youtube_player'], function (x) {
-            var frame_title = tarteaucitron.fixSelfXSS(tarteaucitron.getElemAttr(x, "title") || 'Youtube iframe'),
+            var frame_title = tarteaucitron.getElemAttr(x, "title") || 'Youtube iframe',
                 video_id = tarteaucitron.getElemAttr(x, "videoID"),
                 srcdoc = tarteaucitron.getElemAttr(x, "srcdoc"),
                 loading = tarteaucitron.getElemAttr(x, "loading"),
@@ -4624,7 +4624,7 @@ tarteaucitron.services.youtubeplaylist = {
     "js": function () {
         "use strict";
         tarteaucitron.fallback(['youtube_playlist_player'], function (x) {
-            var frame_title = tarteaucitron.fixSelfXSS(tarteaucitron.getElemAttr(x, "title") || 'Youtube iframe'),
+            var frame_title = tarteaucitron.getElemAttr(x, "title") || 'Youtube iframe',
                 playlist_id = tarteaucitron.getElemAttr(x, "playlistID"),
                 video_width = tarteaucitron.getElemAttr(x, "width"),
                 frame_width = 'width=',
@@ -4776,11 +4776,11 @@ tarteaucitron.services.issuu = {
     "js": function () {
         "use strict";
         tarteaucitron.fallback(['issuu_player'], function (x) {
-            var frame_title = tarteaucitron.fixSelfXSS(x.getAttribute("title") || 'Issuu iframe'),
-                issuu_id = x.getAttribute("issuuID"),
-                issuu_width = x.getAttribute("width"),
+            var frame_title = tarteaucitron.getElemAttr(x, "title") || 'Issuu iframe',
+                issuu_id = tarteaucitron.getElemAttr(x, "issuuID"),
+                issuu_width = tarteaucitron.getElemAttr(x, "width"),
                 frame_width = 'width=',
-                issuu_height = x.getAttribute("height"),
+                issuu_height = tarteaucitron.getElemAttr(x, "height"),
                 frame_height = 'height=',
                 issuu_frame,
                 issuu_embed;
@@ -5192,14 +5192,14 @@ tarteaucitron.services.matterport = {
     "js": function () {
         "use strict";
         tarteaucitron.fallback(['matterport'], function (x) {
-            var frame_title = tarteaucitron.fixSelfXSS(x.getAttribute("title") || 'Matterport iframe'),
-                matterport_id = x.getAttribute("matterportID"),
-                matterport_width = x.getAttribute("width"),
+            var frame_title = tarteaucitron.getElemAttr(x, "title") || 'Matterport iframe',
+                matterport_id = tarteaucitron.getElemAttr(x, "matterportID"),
+                matterport_width = tarteaucitron.getElemAttr(x, "width"),
                 frame_width = 'width=',
-                matterport_height = x.getAttribute("height"),
+                matterport_height = tarteaucitron.getElemAttr(x, "height"),
                 frame_height = 'height=',
-                matterport_parameters = x.getAttribute("parameters"),
-                matterport_allowfullscreen = x.getAttribute('allowfullscreen'),
+                matterport_parameters = tarteaucitron.getElemAttr(x, "parameters"),
+                matterport_allowfullscreen = tarteaucitron.getElemAttr(x, 'allowfullscreen'),
                 matterport_frame;
 
             if (matterport_id === undefined) {
@@ -5461,12 +5461,12 @@ tarteaucitron.services.ausha = {
     js: function () {
         "use strict";
         tarteaucitron.fallback(['ausha_player'], function (x) {
-            var player_height = x.getAttribute('data-height'),
-                podcast_id = x.getAttribute('data-podcast-id'),
-                player_id = x.getAttribute('data-player-id'),
-                playlist = x.getAttribute('data-playlist'),
-                useshowid = x.getAttribute('data-useshowid'),
-                color = x.getAttribute('data-color');
+            var player_height = tarteaucitron.getElemAttr(x, 'data-height'),
+                podcast_id = tarteaucitron.getElemAttr(x, 'data-podcast-id'),
+                player_id = tarteaucitron.getElemAttr(x, 'data-player-id'),
+                playlist = tarteaucitron.getElemAttr(x, 'data-playlist'),
+                useshowid = tarteaucitron.getElemAttr(x, 'data-useshowid'),
+                color = tarteaucitron.getElemAttr(x, 'data-color');
 
             if (podcast_id === undefined) {
                 return "";
@@ -5526,17 +5526,17 @@ tarteaucitron.services.bandcamp = {
     js: function () {
         "use strict";
         tarteaucitron.fallback(['bandcamp_player'], function (x) {
-            var frame_title = tarteaucitron.fixSelfXSS(x.getAttribute("title") || 'Bandcamp iframe'),
-                album_id = x.getAttribute("albumID"),
-                bandcamp_width = x.getAttribute("width"),
+            var frame_title = tarteaucitron.getElemAttr(x, "title") || 'Bandcamp iframe',
+                album_id = tarteaucitron.getElemAttr(x, "albumID"),
+                bandcamp_width = tarteaucitron.getElemAttr(x, "width"),
                 frame_width = 'width=',
-                bandcamp_height = x.getAttribute("height"),
+                bandcamp_height = tarteaucitron.getElemAttr(x, "height"),
                 frame_height = 'height=',
                 attrs = ["size", "bgcol", "linkcol", "artwork", "minimal", "tracklist", "package", "transparent"],
                 params = attrs.filter(function (a) {
-                    return x.getAttribute(a) !== null;
+                    return tarteaucitron.getElemAttr(x, a) !== null;
                 }).map(function (a) {
-                    if (a && a.length > 0) return a + "=" + x.getAttribute(a);
+                    if (a && a.length > 0) return a + "=" + tarteaucitron.getElemAttr(x, a);
                 }).join("/");
 
             if (album_id === null) {
@@ -5580,9 +5580,9 @@ tarteaucitron.services.discord = {
     "js": function () {
         "use strict";
         tarteaucitron.fallback(['discord_widget'], function (x) {
-            var id = x.getAttribute("guildID"),
-                width = x.getAttribute("width"),
-                height = x.getAttribute("height")
+            var id = tarteaucitron.getElemAttr(x, "guildID"),
+                width = tarteaucitron.getElemAttr(x, "width"),
+                height = tarteaucitron.getElemAttr(x, "height")
             var widgetURL = "https://discord.com/widget?id=" + id;
             return "<iframe width=\"" + width + "\" height=\"" + height + "\" src=\"" + widgetURL + "\"></iframe>";
         });
@@ -5609,9 +5609,9 @@ tarteaucitron.services.maps_noapi = {
     "js": function () {
         "use strict";
         tarteaucitron.fallback(['googlemaps_embed'], function (x) {
-            var id = x.getAttribute("id"),
-                width = x.getAttribute("width"),
-                height = x.getAttribute("height")
+            var id = tarteaucitron.getElemAttr(x, "id"),
+                width = tarteaucitron.getElemAttr(x, "width"),
+                height = tarteaucitron.getElemAttr(x, "height")
             var widgetURL = "https://www.google.com/maps/embed?pb=" + id;
             return "<iframe width=\"" + width + "\" height=\"" + height + "\" src=\"" + widgetURL + "\" style=\"border:0;\" allowfullscreen=\"\" loading=\"lazy\"></iframe>";
         });
@@ -5658,9 +5658,9 @@ tarteaucitron.services.fculture = {
     "js": function () {
         "use strict";
         tarteaucitron.fallback(['fculture_embed'], function (x) {
-            var id = x.getAttribute('id'),
-                width = x.getAttribute('width'),
-                height = x.getAttribute('height');
+            var id = tarteaucitron.getElemAttr(x, 'id'),
+                width = tarteaucitron.getElemAttr(x, 'width'),
+                height = tarteaucitron.getElemAttr(x, 'height');
             return "<iframe src=\"https://www.franceculture.fr/player/export-reecouter?content=" + id + "\" height=\"" + height + "\" width=\"" + width + "\"></iframe>"
         });
     },
@@ -5682,11 +5682,11 @@ tarteaucitron.services.acast = {
     "js": function () {
         "use strict";
         tarteaucitron.fallback(['acast_embed'], function (x) {
-            var id = x.getAttribute('id1'),
-                id2 = x.getAttribute('id2'),
-                width = x.getAttribute('width'),
-                height = x.getAttribute('height'),
-                seek = x.getAttribute('seek');
+            var id = tarteaucitron.getElemAttr(x, 'id1'),
+                id2 = tarteaucitron.getElemAttr(x, 'id2'),
+                width = tarteaucitron.getElemAttr(x, 'width'),
+                height = tarteaucitron.getElemAttr(x, 'height'),
+                seek = tarteaucitron.getElemAttr(x, 'seek');
             var widgetURL = "https://embed.acast.com/" + id + "/" + id2 + "?seek=" + seek;
             return "<iframe title=\"Embed Player\" width=\"" + width + "\" height=\"" + height + "\" src=\"" + widgetURL + "\" scrolling=\"no\" frameBorder=\"0\" style=\"border: none; overflow: hidden;\"></iframe>";
         });
@@ -5709,12 +5709,12 @@ tarteaucitron.services.mixcloud = {
     "js": function () {
         "use strict";
         tarteaucitron.fallback(['mixcloud_embed'], function (x) {
-            var id = x.getAttribute('id'),
-                hidecover = x.getAttribute('hidecover'),
-                mini = x.getAttribute('mini'),
-                light = x.getAttribute('light'),
-                width = x.getAttribute('width'),
-                height = x.getAttribute('height');
+            var id = tarteaucitron.getElemAttr(x, 'id'),
+                hidecover = tarteaucitron.getElemAttr(x, 'hidecover'),
+                mini = tarteaucitron.getElemAttr(x, 'mini'),
+                light = tarteaucitron.getElemAttr(x, 'light'),
+                width = tarteaucitron.getElemAttr(x, 'width'),
+                height = tarteaucitron.getElemAttr(x, 'height');
             return "<iframe width=\"" + width + "\" height=\"" + height + "\" src=\"https://www.mixcloud.com/widget/iframe/?hide_cover=" + hidecover + "&mini=" + mini + "&light=" + light + "&feed=" + id + "\" frameborder=\"0\" ></iframe>";
         });
     },
@@ -5736,9 +5736,9 @@ tarteaucitron.services.gagenda = {
     "js": function () {
         "use strict";
         tarteaucitron.fallback(['gagenda_embed'], function (x) {
-            var calendar_data = x.getAttribute('data'),
-                width = x.getAttribute('width'),
-                height = x.getAttribute('height');
+            var calendar_data = tarteaucitron.getElemAttr(x, 'data'),
+                width = tarteaucitron.getElemAttr(x, 'width'),
+                height = tarteaucitron.getElemAttr(x, 'height');
             return "<iframe loarding=\"lazy\" width=\"" + width + "\" height=\"" + height + "\" src=\"https://www.google.com/calendar/embed?" + calendar_data + "\" frameborder=\"0\" scrolling=\"no\" style=\"border-width:0\"></iframe>";
         });
     },
@@ -5760,9 +5760,9 @@ tarteaucitron.services.gdocs = {
     "js": function () {
         "use strict";
         tarteaucitron.fallback(['gdocs_embed'], function (x) {
-            var id = x.getAttribute('id'),
-                width = x.getAttribute('width'),
-                height = x.getAttribute('height');
+            var id = tarteaucitron.getElemAttr(x, 'id'),
+                width = tarteaucitron.getElemAttr(x, 'width'),
+                height = tarteaucitron.getElemAttr(x, 'height');
             return "<iframe width=\"" + width + "\" height=\"" + height + "\" src=\"https://docs.google.com/document/d/e/" + id + "/pub?embedded=true\"></iframe>";
         });
     },
@@ -5784,10 +5784,10 @@ tarteaucitron.services.gsheets = {
     "js": function () {
         "use strict";
         tarteaucitron.fallback(['gsheets_embed'], function (x) {
-            var id = x.getAttribute('id'),
-                width = x.getAttribute('width'),
-                height = x.getAttribute('height'),
-                headers = x.getAttribute('headers');
+            var id = tarteaucitron.getElemAttr(x, 'id'),
+                width = tarteaucitron.getElemAttr(x, 'width'),
+                height = tarteaucitron.getElemAttr(x, 'height'),
+                headers = tarteaucitron.getElemAttr(x, 'headers');
             return "<iframe width=\"" + width + "\" height=\"" + height + "\" src=\"https://docs.google.com/spreadsheets/d/e/" + id + "/pubhtml?widget=true&amp;headers=" + headers + "\"></iframe>";
         });
     },
@@ -5809,12 +5809,12 @@ tarteaucitron.services.gslides = {
     "js": function () {
         "use strict";
         tarteaucitron.fallback(['gslides_embed'], function (x) {
-            var id = x.getAttribute('id'),
-                width = x.getAttribute('width'),
-                height = x.getAttribute('height'),
-                autostart = x.getAttribute('autostart'),
-                loop = x.getAttribute('loop'),
-                delay = x.getAttribute('delay');
+            var id = tarteaucitron.getElemAttr(x, 'id'),
+                width = tarteaucitron.getElemAttr(x, 'width'),
+                height = tarteaucitron.getElemAttr(x, 'height'),
+                autostart = tarteaucitron.getElemAttr(x, 'autostart'),
+                loop = tarteaucitron.getElemAttr(x, 'loop'),
+                delay = tarteaucitron.getElemAttr(x, 'delay');
             return "<iframe width=\"" + width + "\" height=\"" + height + "\" src=\"https://docs.google.com/presentation/d/e/" + id + "/embed?start=" + autostart + "&loop=" + loop + "&delayms=" + delay + "\" frameborder=\"0\" allowfullscreen=\"true\" mozallowfullscreen=\"true\" webkitallowfullscreen=\"true\"></iframe>";
         });
     },
@@ -5836,9 +5836,9 @@ tarteaucitron.services.gforms = {
     "js": function () {
         "use strict";
         tarteaucitron.fallback(['gforms_embed'], function (x) {
-            var id = x.getAttribute('id'),
-                width = x.getAttribute('width'),
-                height = x.getAttribute('height');
+            var id = tarteaucitron.getElemAttr(x, 'id'),
+                width = tarteaucitron.getElemAttr(x, 'width'),
+                height = tarteaucitron.getElemAttr(x, 'height');
             return "<iframe width=\"" + width + "\" height=\"" + height + "\" src=\"https://docs.google.com/forms/d/e/" + id + "/viewform?embedded=true\" frameborder=\"0\" marginheight=\"0\" marginwidth=\"0\"></iframe>";
         });
     },
@@ -5949,7 +5949,7 @@ tarteaucitron.services.canalu = {
     "js": function () {
         "use strict";
         tarteaucitron.fallback(['canalu_player'], function (x) {
-            var video_title = tarteaucitron.fixSelfXSS(x.getAttribute("videoTitle")),
+            var video_title = tarteaucitron.getElemAttr(x, "videoTitle"),
                 frame_url = 'https://www.canal-u.tv/embed/' + video_title;
 
             return '<div style="position:relative;padding-bottom:56.25%;padding-top:10px;height:0;overflow:hidden;">' +
@@ -5981,9 +5981,9 @@ tarteaucitron.services.webtvnu = {
     "js": function () {
         "use strict";
         tarteaucitron.fallback(['webtvnu_player'], function (x) {
-            var frame_url = 'https://webtv.normandie-univ.fr/permalink/' + x.getAttribute("videoID") + '/iframe/',
-                width = x.getAttribute("width"),
-                height = x.getAttribute("height");
+            var frame_url = 'https://webtv.normandie-univ.fr/permalink/' + tarteaucitron.getElemAttr(x, "videoID") + '/iframe/',
+                width = tarteaucitron.getElemAttr(x, "width"),
+                height = tarteaucitron.getElemAttr(x, "height");
 
             return '<iframe width="' + width + '" height="' + height + '" src="' + frame_url + '" allowfullscreen="allowfullscreen" allow="autoplay"></iframe>';
         });
@@ -6026,11 +6026,11 @@ tarteaucitron.services.meteofrance = {
     "js": function () {
         "use strict";
         tarteaucitron.fallback(['tac_meteofrance'], function (x) {
-            var frame_title = tarteaucitron.fixSelfXSS(x.getAttribute("title") || 'Météo France iframe'),
-                width = x.getAttribute("width"),
-                height = x.getAttribute("height"),
-                insee = x.getAttribute("data-insee"),
-                allowfullscreen = x.getAttribute("allowfullscreen");
+            var frame_title = tarteaucitron.getElemAttr(x, "title") || 'Météo France iframe',
+                width = tarteaucitron.getElemAttr(x, "width"),
+                height = tarteaucitron.getElemAttr(x, "height"),
+                insee = tarteaucitron.getElemAttr(x, "data-insee"),
+                allowfullscreen = tarteaucitron.getElemAttr(x, "allowfullscreen");
 
             return '<iframe title="' + frame_title + '" src="https://meteofrance.com/widget/prevision/' + insee + '" width="' + width + '" height="' + height + '" scrolling="auto" allowtransparency ' + (allowfullscreen == '0' ? '' : ' webkitallowfullscreen mozallowfullscreen allowfullscreen') + '></iframe>';
         });
@@ -6057,7 +6057,7 @@ tarteaucitron.services.m6meteo = {
     "js": function () {
         "use strict";
         tarteaucitron.fallback(['tac_m6meteo'], function (x) {
-            var id = x.getAttribute("data-id");
+            var id = tarteaucitron.getElemAttr(x, "data-id");
 
             tarteaucitron.addScript('https://www.meteocity.com/widget/js/'+id);
 


### PR DESCRIPTION
Quite a few services were still not using the XSS proof method to read a DOM element attribute.