### PR TITLE
fix: remove legacy entries from the Hotjar's cookies list

### DIFF
--- a/tarteaucitron.services.js
+++ b/tarteaucitron.services.js
@@ -5131,7 +5131,7 @@ tarteaucitron.services.hotjar = {
     "name": "Hotjar",
     "uri": "https://help.hotjar.com/hc/en-us/categories/115001323967-About-Hotjar",
     "needConsent": true,
-    "cookies": ["hjClosedSurveyInvites", "_hjDonePolls", "_hjMinimizedPolls", "_hjDoneTestersWidgets", "_hjMinimizedTestersWidgets", "_hjDoneSurveys", "_hjIncludedInSample", "_hjShownFeedbackMessage", "_hjAbsoluteSessionInProgress", "_hjIncludeInPageviewSample", "_hjid"],
+    "cookies": ["hjClosedSurveyInvites", "_hjDonePolls", "_hjMinimizedPolls", "_hjShownFeedbackMessage", "_hjAbsoluteSessionInProgress", "_hjid"],
     "js": function () {
         "use strict";
         if (tarteaucitron.user.hotjarId === undefined || tarteaucitron.user.HotjarSv === undefined) {


### PR DESCRIPTION
Hi folks,

One of our users, also using your tool, brought to our attention that the list of cookies outlined under Hotjar is outdated. As I had a quick check, indeed, there are few entries [here](https://github.com/AmauriC/tarteaucitron.js/blob/8a1735e42e0d49c1ceef16a217622a0c28593706/tarteaucitron.services.js#L5134) that are no longer relevant for quite long time.

To remove the unused ones, the line was updated to

```"cookies": ["hjClosedSurveyInvites", "_hjDonePolls", "_hjMinimizedPolls", "_hjShownFeedbackMessage", "_hjAbsoluteSessionInProgress", "_hjid"],```
In case you'd be interested in seeing our up to date list of the cookies, here's our [docs](https://help.hotjar.com/hc/en-us/articles/6952777582999-Cookies-Set-by-the-Hotjar-Tracking-Code) article that covers them

Closes #1180

Cheers