### PR TITLE
feat(matomocloud): Improve cookieless tracking fallback

### DIFF
--- a/tarteaucitron.services.js
+++ b/tarteaucitron.services.js
@@ -5517,11 +5517,17 @@ tarteaucitron.services.matomocloud = {
         /*
          * https://developer.matomo.org/guides/tracking-javascript-guide#tracking-one-domain-and-its-subdomains-in-the-same-website
          */
-        if (tarteaucitron.user.matomoCustomCookieDomain !== undefined) {
+        if (
+            tarteaucitron.user.matomoCustomCookieDomain !== undefined &&
+            tarteaucitron.user.matomoCustomCookieDomain !== ''
+        ) {
             // Share the tracking cookie across example.com, www.example.com, subdomain.example.com, ...
             window._paq.push(["setCookieDomain", tarteaucitron.user.matomoCustomCookieDomain]);
         }
-        if (tarteaucitron.user.matomoWebsiteDomains !== undefined && Array.isArray(tarteaucitron.user.matomoWebsiteDomains)) {
+        if (
+            tarteaucitron.user.matomoWebsiteDomains !== undefined &&
+            Array.isArray(tarteaucitron.user.matomoWebsiteDomains)
+        ) {
             // Tell Matomo the website domain so that clicks on these domains are not tracked as 'Outlinks'
             window._paq.push(["setDomains", tarteaucitron.user.matomoWebsiteDomains]);
         }
@@ -5562,7 +5568,10 @@ tarteaucitron.services.matomocloud = {
         /*
          * Allow website to use a different SiteID for cookieless tracking
          */
-        if (tarteaucitron.user.matomoFallbackId === undefined) {
+        if (
+            tarteaucitron.user.matomoFallbackId === undefined ||
+            tarteaucitron.user.matomoFallbackId === ''
+        ) {
             tarteaucitron.user.matomoFallbackId = tarteaucitron.user.matomoId;
         }
 
@@ -5587,11 +5596,17 @@ tarteaucitron.services.matomocloud = {
         /*
          * https://developer.matomo.org/guides/tracking-javascript-guide#tracking-one-domain-and-its-subdomains-in-the-same-website
          */
-        if (tarteaucitron.user.matomoCustomCookieDomain !== undefined) {
+        if (
+            tarteaucitron.user.matomoCustomCookieDomain !== undefined &&
+            tarteaucitron.user.matomoCustomCookieDomain !== ''
+        ) {
             // Share the tracking cookie across example.com, www.example.com, subdomain.example.com, ...
             window._paq.push(["setCookieDomain", tarteaucitron.user.matomoCustomCookieDomain]);
         }
-        if (tarteaucitron.user.matomoWebsiteDomains !== undefined && Array.isArray(tarteaucitron.user.matomoWebsiteDomains)) {
+        if (
+            tarteaucitron.user.matomoWebsiteDomains !== undefined &&
+            Array.isArray(tarteaucitron.user.matomoWebsiteDomains)
+        ) {
             // Tell Matomo the website domain so that clicks on these domains are not tracked as 'Outlinks'
             window._paq.push(["setDomains", tarteaucitron.user.matomoWebsiteDomains]);
         }

--- a/tarteaucitron.services.js
+++ b/tarteaucitron.services.js
@@ -499,11 +499,11 @@ tarteaucitron.services.freshsalescrm = {
   "cookies": [],
   "js": function () {
     "use strict";
-    
+
     if (tarteaucitron.user.freshsalescrmId === undefined) {
      return;
     }
-    
+
     tarteaucitron.addScript('https://eu.fw-cdn.com/' + tarteaucitron.user.freshsalescrmId + '.js');
   }
 };
@@ -5497,6 +5497,14 @@ tarteaucitron.services.matomocloud = {
         window._paq.push(["setConsentGiven"]);
         window._paq.push(["setSiteId", tarteaucitron.user.matomoId]);
         window._paq.push(["setTrackerUrl", tarteaucitron.user.matomoHost + "matomo.php"]);
+        /*
+         * If a fallback SiteID is configured for CookieLess tracking, add it as an additional tracker
+         * when cookie have been accepted.
+         */
+        if (tarteaucitron.user.matomoFallbackId !== undefined) {
+            window._paq.push(['addTracker', tarteaucitron.user.matomoHost + "matomo.php", tarteaucitron.user.matomoFallbackId]);
+        }
+
         window._paq.push(["enableLinkTracking"]);
 
         if (tarteaucitron.user.matomoDontTrackPageView !== true) {
@@ -5505,6 +5513,17 @@ tarteaucitron.services.matomocloud = {
 
         if (tarteaucitron.user.matomoFullTracking === true) {
             window._paq.push(["trackAllContentImpressions"]);
+        }
+        /*
+         * https://developer.matomo.org/guides/tracking-javascript-guide#tracking-one-domain-and-its-subdomains-in-the-same-website
+         */
+        if (tarteaucitron.user.matomoCustomCookieDomain !== undefined) {
+            // Share the tracking cookie across example.com, www.example.com, subdomain.example.com, ...
+            window._paq.push(["setCookieDomain", tarteaucitron.user.matomoCustomCookieDomain]);
+        }
+        if (tarteaucitron.user.matomoWebsiteDomains !== undefined && Array.isArray(tarteaucitron.user.matomoWebsiteDomains)) {
+            // Tell Matomo the website domain so that clicks on these domains are not tracked as 'Outlinks'
+            window._paq.push(["setDomains", tarteaucitron.user.matomoWebsiteDomains]);
         }
 
         if (tarteaucitron.user.matomoCustomJSPath === undefined || tarteaucitron.user.matomoCustomJSPath == '') {
@@ -5540,13 +5559,42 @@ tarteaucitron.services.matomocloud = {
         if (tarteaucitron.user.matomoId === undefined) {
             return;
         }
+        /*
+         * Allow website to use a different SiteID for cookieless tracking
+         */
+        if (tarteaucitron.user.matomoFallbackId === undefined) {
+            tarteaucitron.user.matomoFallbackId = tarteaucitron.user.matomoId;
+        }
 
         window._paq = window._paq || [];
-        window._paq.push(["requireConsent"]);
-        window._paq.push(["setSiteId", tarteaucitron.user.matomoId]);
+
+        /*
+         * Allow website to switch to cookie-less tracking if user has not given consent.
+         * Make sure you configured your Matomo site to be GDPR-compliant in cookieless mode.
+         */
+        if (tarteaucitron.user.matomoCookieLessFallback === true) {
+            // Do not use cookies but track requests
+            window._paq.push(["requireCookieConsent"]);
+        } else {
+            // Do not track anything
+            window._paq.push(["requireConsent"]);
+        }
+        window._paq.push(["setSiteId", tarteaucitron.user.matomoFallbackId]);
         window._paq.push(["setTrackerUrl", tarteaucitron.user.matomoHost + "matomo.php"]);
         window._paq.push(["trackPageView"]);
         window._paq.push(["enableLinkTracking"]);
+
+        /*
+         * https://developer.matomo.org/guides/tracking-javascript-guide#tracking-one-domain-and-its-subdomains-in-the-same-website
+         */
+        if (tarteaucitron.user.matomoCustomCookieDomain !== undefined) {
+            // Share the tracking cookie across example.com, www.example.com, subdomain.example.com, ...
+            window._paq.push(["setCookieDomain", tarteaucitron.user.matomoCustomCookieDomain]);
+        }
+        if (tarteaucitron.user.matomoWebsiteDomains !== undefined && Array.isArray(tarteaucitron.user.matomoWebsiteDomains)) {
+            // Tell Matomo the website domain so that clicks on these domains are not tracked as 'Outlinks'
+            window._paq.push(["setDomains", tarteaucitron.user.matomoWebsiteDomains]);
+        }
 
         if (tarteaucitron.user.matomoCustomJSPath === undefined || tarteaucitron.user.matomoCustomJSPath == '') {
             tarteaucitron.addScript('https://cdn.matomo.cloud/matomo.js', '', '', true, 'defer', true);


### PR DESCRIPTION
- Added `tarteaucitron.user.matomoCookieLessFallback` `boolean` parameter to allow tracking without cookies in fallback. For the moment, Matomo **does not track anything** unless consent has been given. \
Related to #1085 #1028
- Added `tarteaucitron.user.matomoCustomCookieDomain` `string` parameter to change  `setCookieDomain` option (https://developer.matomo.org/guides/tracking-javascript-guide#tracking-one-domain-and-its-subdomains-in-the-same-website)
- Added `tarteaucitron.user.matomoWebsiteDomains` `array<string>` parameter to declare same-site domains list to `setDomains` option
- Added `tarteaucitron.user.matomoFallbackId` `number` parameter to use a different *Site ID* for fallback tracking. Website may use a different Matomo site to collect cookie-less statistics. If so, we add the fallback Site ID with `addTracker` option when consent is given.

This PR should not break compatibility with existing `matomocloud` service. These features are optional and only triggered when defining parameters above.
