### PR TITLE
fix(tarteaucitron.js): adds a conditionnal for empty lang attribute

### DIFF
--- a/tarteaucitron.js
+++ b/tarteaucitron.js
@@ -2077,7 +2077,7 @@ var tarteaucitron = {
         }
 
         // get the html lang
-        if (document.documentElement.getAttribute("lang") !== undefined && document.documentElement.getAttribute("lang") !== null) {
+        if (document.documentElement.getAttribute("lang") !== undefined && document.documentElement.getAttribute("lang") !== null && documentElement.getAttribute("lang") !== "") {
             if (availableLanguages.indexOf(document.documentElement.getAttribute("lang").substr(0, 2)) !== -1) {
                 return document.documentElement.getAttribute("lang").substr(0, 2);
             }


### PR DESCRIPTION
So when the `lang` attribute is empty : `<html lang>`, the `getLanguage` method is not able to see it and goes in the conditionnal : 
```js 
if (document.documentElement.getAttribute("lang") !== undefined && document.documentElement.getAttribute("lang") !== null) {
    if (availableLanguages.indexOf(document.documentElement.getAttribute("lang").substr(0, 2)) !== -1) {
        return document.documentElement.getAttribute("lang").substr(0, 2);
    }
}
```

And it returns ... `""` so the lang script does not load :'( 

This PR fixes this behavior.