### PR TITLE
Fix consent event names in matomo sevice

### DIFF
--- a/tarteaucitron.services.js
+++ b/tarteaucitron.services.js
@@ -5597,8 +5597,8 @@ tarteaucitron.services.matomocloud = {
         }
 
         window._paq = window._paq || [];
-        window._paq.push(["requireConsent"]);
-        window._paq.push(["setConsentGiven"]);
+        window._paq.push(["requireCookieConsent"]);
+        window._paq.push(["setCookieConsentGiven"]);
         window._paq.push(["setSiteId", tarteaucitron.user.matomoId]);
         window._paq.push(["setTrackerUrl", tarteaucitron.user.matomoHost + "matomo.php"]);
         window._paq.push(["enableLinkTracking"]);
@@ -5646,7 +5646,7 @@ tarteaucitron.services.matomocloud = {
         }
 
         window._paq = window._paq || [];
-        window._paq.push(["requireConsent"]);
+        window._paq.push(["requireCookieConsent"]);
         window._paq.push(["setSiteId", tarteaucitron.user.matomoId]);
         window._paq.push(["setTrackerUrl", tarteaucitron.user.matomoHost + "matomo.php"]);
         window._paq.push(["trackPageView"]);


### PR DESCRIPTION
We realised we were not getting analytics for users who denied cookies. After some digging in the documentation, we found the [page about tracking these users](https://matomo.org/faq/new-to-piwik/how-can-i-still-track-a-visitor-without-cookies-even-if-they-decline-the-cookie-consent/). The event names in this page are `requireCookieConsent` and `setCookieConsentGiven` whereas the current implementation uses `requireConsent` and `setConsentGiven`.
With this modification we started getting event triggers correctly (cf. screenshots).

Before (no consent) : 
![image](https://github.com/user-attachments/assets/093fa72a-adc0-454c-b752-1fe90e73f2b3)

Before (with consent) : 
![image](https://github.com/user-attachments/assets/7e839801-d235-4b37-92cf-955166cf0920)

After (no consent) : 
![image](https://github.com/user-attachments/assets/f556e158-137a-4924-be04-9aa20b6d9621)

After (with consent) : 
![image](https://github.com/user-attachments/assets/e14f158b-2085-4893-8825-cc1beca1f051)