### PR TITLE
Add a "consent" call after clarity service initialization 

### DIFF
--- a/tarteaucitron.services.js
+++ b/tarteaucitron.services.js
@@ -571,11 +571,11 @@ tarteaucitron.services.freshsalescrm = {
   "cookies": [],
   "js": function () {
     "use strict";
-    
+
     if (tarteaucitron.user.freshsalescrmId === undefined) {
      return;
     }
-    
+
     tarteaucitron.addScript('https://eu.fw-cdn.com/' + tarteaucitron.user.freshsalescrmId + '.js');
   }
 };
@@ -2472,7 +2472,9 @@ tarteaucitron.services.clarity = {
 
         window["clarity"] = window["clarity"] || function () { (window["clarity"].q = window["clarity"].q || []).push(arguments) };
 
-        tarteaucitron.addScript('https://www.clarity.ms/tag/' + tarteaucitron.user.clarity);
+        tarteaucitron.addScript('https://www.clarity.ms/tag/' + tarteaucitron.user.clarity, '', function() {
+            window["clarity"]("consent");
+        });
     }
 };
 


### PR DESCRIPTION
as documented on the clarity API documentation :
https://learn.microsoft.com/en-us/clarity/setup-and-installation/clarity-api 
and as stated in this FAQ : https://learn.microsoft.com/en-us/clarity/faq#why-does-clarity-require-explicit-consent-in-the-european-economic-area--eea---uk--and-switzerland--

we need to add a "consent" call after initialization of the clarity service