### PR TITLE
Include percentage in AlertSmall aria-label and title

### DIFF
--- a/tarteaucitron.js
+++ b/tarteaucitron.js
@@ -1454,9 +1454,23 @@ var tarteaucitron = {
             }
             sum -= sumToRemove;
 
-            tarteaucitron.userInterface.css(c + 'DotGreen', 'width', ((100 / sum) * nbAllowed) + '%');
-            tarteaucitron.userInterface.css(c + 'DotYellow', 'width', ((100 / sum) * nbPending) + '%');
-            tarteaucitron.userInterface.css(c + 'DotRed', 'width', ((100 / sum) * nbDenied) + '%');
+            const percentages = {
+                DotGreen: (100 / sum) * nbAllowed,
+                DotYellow: (100 / sum) * nbPending,
+                DotRed: (100 / sum) * nbDenied
+            };
+
+            for (const [colorKey, value] of Object.entries(percentages)) {
+                tarteaucitron.userInterface.css(c + colorKey, 'width', value + '%');
+            }
+
+            if (tarteaucitron.parameters.showAlertSmall === true) {
+                const percentAllowed = percentages.DotGreen;
+                const label = tarteaucitron.lang.alertSmall + " - " + percentAllowed + "% " + tarteaucitron.lang.allowed + " " + tarteaucitron.lang.modalWindow;
+                const managerEl = document.getElementById(c + 'Manager');
+                managerEl.setAttribute('aria-label', label);
+                managerEl.setAttribute('title', label);
+            }
 
             if (nbDenied === 0 && nbPending === 0) {
                 tarteaucitron.userInterface.removeClass(c + 'AllDenied', c + 'IsSelected');


### PR DESCRIPTION
### Objectif :
Amélioration de l’accessibilité pour les utilisateurs de lecteurs d’écran en rendant disponible une information actuellement uniquement visuelle (le pourcentage de cookies acceptés).

### Ce que fait cette PR
- Ajoute un aria-label (et un title) dynamique au bouton alertSmall #tarteaucitronManager.
- Ce label contient le pourcentage de cookies acceptés, par exemple : "Gestion des services - 60% accepté (fenêtre modale)".
- Rend cette information accessible aux technologies d’assistance.

###  Contexte accessibilité
Cette modification répond aux règles suivantes du RGAA 4.1 :

> Dans chaque page web, l’information ne doit pas être donnée uniquement par la couleur.
> Dans chaque page web, l’information ne doit pas être donnée par la forme, taille ou position

La barre colorée (rouge / verte) représentant le pourcentage de cookies acceptés étant purement visuelle, il est nécessaire de la compléter par une alternative textuelle accessible.