### PR TITLE
Improve i18n

### DIFF
--- a/tarteaucitron.js
+++ b/tarteaucitron.js
@@ -2290,31 +2290,41 @@ var tarteaucitron = {
     "getLanguage": function () {
         "use strict";
 
-        var availableLanguages = 'ar,bg,ca,cn,cs,da,de,et,el,en,es,fi,fr,hr,hu,it,ja,ko,lb,lt,lv,nl,no,oc,pl,pt,ro,ru,se,sk,sq,sv,tr,uk,vi,zh',
-            defaultLanguage = 'en';
+        const availableLanguages = new Set('ar,bg,ca,cn,cs,da,de,et,el,en,es,fi,fr,hr,hu,it,ja,ko,lb,lt,lv,nl,no,oc,pl,pt,ro,ru,se,sk,sq,sv,tr,uk,vi,zh'.split(','));
+        let defaultLanguage = 'en';
 
         if (tarteaucitronForceLanguage !== '') {
-            if (availableLanguages.indexOf(tarteaucitronForceLanguage) !== -1) {
+            if (availableLanguages.has(tarteaucitronForceLanguage)) {
                 return tarteaucitronForceLanguage;
             }
         }
 
-        // get the html lang
-        if (document.documentElement.getAttribute("lang") !== undefined && document.documentElement.getAttribute("lang") !== null && document.documentElement.getAttribute("lang") !== "") {
-            if (availableLanguages.indexOf(document.documentElement.getAttribute("lang").substr(0, 2)) !== -1) {
-                return document.documentElement.getAttribute("lang").substr(0, 2);
+        const failbackLanguages = {};
+
+        availableLanguages.forEach(code => {
+            const base = code.split('-')[0];
+            if (!failbackLanguages[base]) {
+                failbackLanguages[base] = code;
             }
-        }
+        });
 
-        if (!navigator) { return defaultLanguage; }
+        const userLanguages =  [...new Set([navigator.languages, [document.documentElement.getAttribute("lang")], [navigator.language], [navigator.browserLanguage], [navigator.systemLanguage], [navigator.userLang]].flat(1).filter(Boolean))];
 
-        var lang = navigator.language || navigator.browserLanguage ||
-                navigator.systemLanguage || navigator.userLang || null,
-            userLanguage = lang ? lang.substr(0, 2) : null;
+            for (const lang of userLanguages) {
+                if (availableLanguages.has(lang)) {
+                    return lang;
+                }
 
-        if (availableLanguages.indexOf(userLanguage) !== -1) {
-            return userLanguage;
-        }
+                const shortLang = lang.split(/[-_]/)[0].toLowerCase();
+                
+                if (availableLanguages.has(shortLang)) {
+                    return shortLang;
+                }
+    
+                if (failbackLanguages[shortLang]) {
+                    return failbackLanguages[shortLang];
+                }
+            };
 
         return defaultLanguage;
     },


### PR DESCRIPTION
In short:
Correct the iso code being cut in 2 characters
Improve the language match lookup

In details:

the iso code cut en 2 characters is an issue with languages sharing the first two letters.
Example, Kabyle (kab) would be cut as "ka", and so would Kamba (kam), Georgian(kat), Kawi (kaw) and many more.
So I chose to cut the ISO code with the (-) separator instead.
I wanted to go further with the intent to find a match. I noticed what is in the header _accepted_language_ was not used to build **userLanguage**, I decided to create a table with it and then the HTML tag with all the previous element used to guess the language the user reads.

With that table the code parsed it to find a match:

1) exact match, we keep it, else we try harder.
Example: user declares "fr, it, en-US", tarteaucitron has French translation (fr), we use it

2) we keep the root language code and remove the territory part.
Example: user declares "fr-FR, it, en", tarteaucitron has no translation explicit for French as talked in France, we use the generic "fr" translation available.

3) we keep the root language code for the translations available. But at the moment tarteaucitron has no translations specific to different territories.
Example: user declares "pt-PT, es, en" but tarteaucitron only has "pt-BR", Brazilian Portuguese will be used.

I took into account the possibility that people misuse the (-) separator, so '_' is also checked, and I normalized the lowercase. This is mainly that the part that gets the language from the HTML tag. When adding a new language, one must check that **availableLanguages** is properly formed.

I added a type to defaultLanguage, I hope this is okay.

As today, this code is really to handle in a smarter way, I think, languages, and is ready for more precised translations according to territorial varieties.
 