### PR TITLE
feat: add optional banner headline and optional service description

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ tarteaucitronCustomText = {
     'title': 'Support client',
   },
   'close': 'Enregistrer et fermer',
+  'bannerHeading': 'Nous respectons votre vie privée',
 };
 tarteaucitron.init(...);
 ```
@@ -143,6 +144,24 @@ tarteaucitronCustomText = {
   'engage-twitter': 'Follow us on Twitter!'
 };
 ```
+
+You can set additional descriptions for services. For example:
+```js
+tarteaucitronCustomText = {
+  'desc-googleanalytics': 'Google Analytics nous aide à comprendre comment les visiteurs utilisent notre site web.'
+};
+```
+Alternatively this can be set directly at the service object:
+```js
+tarteaucitron.services.mycustomservice = {
+    "key": "mycustomservice",
+    "type": "analytic",
+    "name": "Mes services",
+    "description": "Ce service fait quelque chose.",
+    // ...
+};
+```
+
 <!--
 # Thanks to the sponsors 😊
 

--- a/lang/tarteaucitron.ar.js
+++ b/lang/tarteaucitron.ar.js
@@ -17,6 +17,7 @@ tarteaucitron.lang = {
     "personalize": "تخصيص",
     "close": "اغلاق",
     "closeBanner": "إخفاء لافتة ملفات تعريف الارتباط",
+    "bannerHeading": "",  // empty = no header shown
 
     "privacyUrl": "سياسة الخصوصية",
 

--- a/lang/tarteaucitron.bg.js
+++ b/lang/tarteaucitron.bg.js
@@ -16,6 +16,7 @@ tarteaucitron.lang = {
     "acceptAll": "ОК, приемам всички",
     "close": "Затвори",
     "closeBanner": "Скриване на банера за бисквитки",
+    "bannerHeading": "",  // empty = no header shown
 
     "privacyUrl": "Политика за поверителност",
     

--- a/lang/tarteaucitron.ca.js
+++ b/lang/tarteaucitron.ca.js
@@ -16,6 +16,7 @@ tarteaucitron.lang = {
     "acceptAll": "OK, acceptar totes",
     "close": "Tancar",
     "closeBanner": "Amaga el banner de galetes",
+    "bannerHeading": "",  // empty = no header shown
 
     "privacyUrl": "Política de privacitat",
     

--- a/lang/tarteaucitron.cn.js
+++ b/lang/tarteaucitron.cn.js
@@ -16,6 +16,7 @@ tarteaucitron.lang = {
     "personalize": "个性化",
     "close": "关闭",
     "closeBanner": "隐藏 cookie 横幅",
+    "bannerHeading": "",  // empty = no header shown
 
     "privacyUrl": "保密政策",
 

--- a/lang/tarteaucitron.cs.js
+++ b/lang/tarteaucitron.cs.js
@@ -16,6 +16,7 @@ tarteaucitron.lang = {
     "acceptAll": "OK, přijmout vše",
     "close": "Zavřít",
     "closeBanner": "Skrýt banner souborů cookie",
+    "bannerHeading": "",  // empty = no header shown
 
     "privacyUrl": "Zásady ochrany osobních údajů",
     

--- a/lang/tarteaucitron.da.js
+++ b/lang/tarteaucitron.da.js
@@ -16,6 +16,7 @@ tarteaucitron.lang = {
     "acceptAll": "OK, accepter alle",
     "close": "Luk",
     "closeBanner": "Skjul cookie-banner",
+    "bannerHeading": "",  // empty = no header shown
 
     "privacyUrl": "Fortrolighedspolitik",
 

--- a/lang/tarteaucitron.de.js
+++ b/lang/tarteaucitron.de.js
@@ -16,6 +16,7 @@ tarteaucitron.lang = {
     "acceptAll": "Alle akzeptieren",
     "close": "Schließen",
     "closeBanner": "Cookies-Banner ausblenden",
+    "bannerHeading": "",  // leer = kein Heading angezeigt
 
     "privacyUrl": "Datenschutzbestimmungen",
     

--- a/lang/tarteaucitron.el.js
+++ b/lang/tarteaucitron.el.js
@@ -16,6 +16,7 @@ tarteaucitron.lang = {
     "acceptAll": "OK, αποδοχή όλων",
     "close": "Κλείσιμο",
     "closeBanner": "Απόκρυψη banner cookies",
+    "bannerHeading": "",  // empty = no header shown
 
     "privacyUrl": "Πολιτική απορρήτου",
     

--- a/lang/tarteaucitron.en.js
+++ b/lang/tarteaucitron.en.js
@@ -16,6 +16,7 @@ tarteaucitron.lang = {
     "acceptAll": "OK, accept all",
     "close": "Close",
     "closeBanner": "Hide cookie banner",
+    "bannerHeading": "",  // empty = no header shown
 
     "privacyUrl": "Privacy policy",
     

--- a/lang/tarteaucitron.es.js
+++ b/lang/tarteaucitron.es.js
@@ -16,6 +16,7 @@ tarteaucitron.lang = {
     "acceptAll": "OK, aceptar todas",
     "close": "Cerrar",
     "closeBanner": "Ocultar la banner de cookies",
+    "bannerHeading": "",  // empty = no header shown
 
     "privacyUrl": "Política de privacidad",
     

--- a/lang/tarteaucitron.et.js
+++ b/lang/tarteaucitron.et.js
@@ -16,6 +16,7 @@ tarteaucitron.lang = {
     "acceptAll": "OK, nõustu kõigiga",
     "close": "Sulge",
     "closeBanner": "Peida küpsiste bänner",
+    "bannerHeading": "",  // empty = no header shown
 
     "privacyUrl": "Privaatsuspoliitika",
     

--- a/lang/tarteaucitron.fi.js
+++ b/lang/tarteaucitron.fi.js
@@ -16,6 +16,7 @@ tarteaucitron.lang = {
     "personalize": "Personoi",
     "close": "Sulje",
     "closeBanner": "Piilota evästebanneri",
+    "bannerHeading": "",  // empty = no header shown
 
     "privacyUrl": "Tietosuoja",
 

--- a/lang/tarteaucitron.fr.js
+++ b/lang/tarteaucitron.fr.js
@@ -17,6 +17,7 @@ tarteaucitron.lang = {
     "personalize": "Personnaliser",
     "close": "Fermer",
     "closeBanner": "Masquer le bandeau des cookies",
+    "bannerHeading": "",  // empty = no header shown
 
     "privacyUrl": "Politique de confidentialité",
 

--- a/lang/tarteaucitron.hr.js
+++ b/lang/tarteaucitron.hr.js
@@ -16,6 +16,7 @@ tarteaucitron.lang = {
     "acceptAll": "U redu, prihvati sve",
     "close": "Zatvori",
     "closeBanner": "Sakrij banner kolačića",
+    "bannerHeading": "",  // empty = no header shown
 
     "privacyUrl": "Pravila privatnosti",
 

--- a/lang/tarteaucitron.hu.js
+++ b/lang/tarteaucitron.hu.js
@@ -16,6 +16,7 @@ tarteaucitron.lang = {
     "acceptAll": "OK, elfogadom",
     "close": "Bezár",
     "closeBanner": "Cookie-szalag elrejtése",
+    "bannerHeading": "",  // empty = no header shown
 
     "privacyUrl": "Adatvédelmi irányelvek",
     

--- a/lang/tarteaucitron.it.js
+++ b/lang/tarteaucitron.it.js
@@ -16,6 +16,7 @@ tarteaucitron.lang = {
     "personalize": "Personalizza",
     "close": "Chiudi",
     "closeBanner": "Nascondi il banner dei cookie",
+    "bannerHeading": "",  // empty = no header shown
 
     "privacyUrl": "Politica sulla riservatezza",
     

--- a/lang/tarteaucitron.ja.js
+++ b/lang/tarteaucitron.ja.js
@@ -16,6 +16,7 @@ tarteaucitron.lang = {
     "acceptAll": "全てに同意する",
     "close": "閉じる",
     "closeBanner": "クッキー バナーを非表示にする",
+    "bannerHeading": "",  // empty = no header shown
 
     "privacyUrl": "プライバシーポリシー",
 

--- a/lang/tarteaucitron.ko.js
+++ b/lang/tarteaucitron.ko.js
@@ -16,6 +16,7 @@ tarteaucitron.lang = {
     "acceptAll": "모두 수락",
     "close": "닫기",
     "closeBanner": "쿠키 배너 숨기기",
+    "bannerHeading": "",  // empty = no header shown
 
     "privacyUrl": "개인 정보 정책",
 

--- a/lang/tarteaucitron.lb.js
+++ b/lang/tarteaucitron.lb.js
@@ -16,6 +16,7 @@ tarteaucitron.lang = {
     "personalize": "Personaliséieren",
     "close": "Zoumaachen",
     "closeBanner": "Verstoppen Cookien Banner",
+    "bannerHeading": "",  // empty = no header shown
 
     "privacyUrl": "Privatsphär Politik",
 

--- a/lang/tarteaucitron.lt.js
+++ b/lang/tarteaucitron.lt.js
@@ -16,6 +16,7 @@ tarteaucitron.lang = {
     "acceptAll": "Gerai, priimu visus",
     "close": "Uždaryti",
     "closeBanner": "Slėpti slapukų reklamjuostę",
+    "bannerHeading": "",  // empty = no header shown
 
     "privacyUrl": "Privatumo politika",
 

--- a/lang/tarteaucitron.lv.js
+++ b/lang/tarteaucitron.lv.js
@@ -16,6 +16,7 @@ tarteaucitron.lang = {
     "acceptAll": "Pieņemt visu",
     "close": "Aizvērt",
     "closeBanner": "Aizvert sīkdatņu joslu",
+    "bannerHeading": "",  // empty = no header shown
 
     "privacyUrl": "Privātuma politika",
 

--- a/lang/tarteaucitron.nl.js
+++ b/lang/tarteaucitron.nl.js
@@ -16,6 +16,7 @@ tarteaucitron.lang = {
     "acceptAll": "OK, accepteer alle",
     "close": "Sluit",
     "closeBanner": "Cookiesbanner verbergen",
+    "bannerHeading": "",  // empty = no header shown
 
     "privacyUrl": "Privacybeleid",
 

--- a/lang/tarteaucitron.no.js
+++ b/lang/tarteaucitron.no.js
@@ -16,6 +16,7 @@ tarteaucitron.lang = {
 	"acceptAll"       : "OK, aksepter alt",
 	"close"           : "Steng",
     "closeBanner"     : "Skjul informasjonskapselbanner",
+	"bannerHeading": "",  // empty = no header shown
 
 	"privacyUrl" : "Personvernregler",
 

--- a/lang/tarteaucitron.oc.js
+++ b/lang/tarteaucitron.oc.js
@@ -17,6 +17,7 @@ tarteaucitron.lang = {
     "personalize": "Personalizar",
     "close": "Tampar",
     "closeBanner": "Rescondre la bandièra de cookies",
+    "bannerHeading": "",  // empty = no header shown
 
     "privacyUrl": "Politica de confidencialitat",
 

--- a/lang/tarteaucitron.pl.js
+++ b/lang/tarteaucitron.pl.js
@@ -16,6 +16,7 @@ tarteaucitron.lang = {
     "acceptAll": "OK, akceptuję wszystko",
     "close": "zamknij",
     "closeBanner": "Ukryj baner dotyczący plików cookie",
+    "bannerHeading": "",  // empty = no header shown
 
     "privacyUrl": "Polityka prywatności",
     

--- a/lang/tarteaucitron.pt.js
+++ b/lang/tarteaucitron.pt.js
@@ -16,6 +16,7 @@ tarteaucitron.lang = {
     "acceptAll": "OK, aceitar tudo",
     "close": "Fechar",
     "closeBanner": "Ocultar banner de cookies",
+    "bannerHeading": "",  // empty = no header shown
 
     "privacyUrl": "Política de Privacidade",
 

--- a/lang/tarteaucitron.ro.js
+++ b/lang/tarteaucitron.ro.js
@@ -16,6 +16,7 @@ tarteaucitron.lang = {
     "acceptAll": "OK, acceptați-le pe toate",
     "close": "Închide",
     "closeBanner": "Ascunde bannerul cookie-urilor",
+    "bannerHeading": "",  // empty = no header shown
 
     "privacyUrl": "Politica de confidentialitate",
     

--- a/lang/tarteaucitron.ru.js
+++ b/lang/tarteaucitron.ru.js
@@ -16,6 +16,7 @@ tarteaucitron.lang = {
     "acceptAll": "Ок, все активировать",
     "close": "Закрыть",
     "closeBanner": "Скрыть баннер cookie",
+    "bannerHeading": "",  // empty = no header shown
 
     "privacyUrl": "Политика конфиденциальности",
     

--- a/lang/tarteaucitron.se.js
+++ b/lang/tarteaucitron.se.js
@@ -16,6 +16,7 @@ tarteaucitron.lang = {
     "acceptAll": "OK, acceptera allt",
     "close": "Stänga",
     "closeBanner": "Dölj cookies banner",
+    "bannerHeading": "",  // empty = no header shown
 
     "privacyUrl": "Integritetspolicy",
 

--- a/lang/tarteaucitron.sk.js
+++ b/lang/tarteaucitron.sk.js
@@ -16,6 +16,7 @@ tarteaucitron.lang = {
     "acceptAll": "OK, prijať všetko",
     "close": "Zatvoriť",
     "closeBanner": "Skryť banner so súbormi cookie",
+    "bannerHeading": "",  // empty = no header shown
 
     "privacyUrl": "Zásady ochrany osobných údajov",
     

--- a/lang/tarteaucitron.sq.js
+++ b/lang/tarteaucitron.sq.js
@@ -16,6 +16,7 @@
     "acceptAll": "OK, prano të gjitha",
     "close": "Mbyll",
     "closeBanner": "Fshih banerin e cookies",
+     "bannerHeading": "",  // empty = no header shown
 
     "privacyUrl": "Politika e privatësisë",
     

--- a/lang/tarteaucitron.sv.js
+++ b/lang/tarteaucitron.sv.js
@@ -16,6 +16,7 @@ tarteaucitron.lang = {
     "acceptAll": "OK, acceptera allt",
     "close": "Stänga",
     "closeBanner": "Dölj cookies banner",
+    "bannerHeading": "",  // empty = no header shown
 
     "privacyUrl": "Integritetspolicy",
 

--- a/lang/tarteaucitron.tr.js
+++ b/lang/tarteaucitron.tr.js
@@ -17,6 +17,7 @@ tarteaucitron.lang = {
     "personalize": "kişiselleştirmek",
     "close": "kapat",
     "closeBanner": "Çerez banner'ını gizle",
+    "bannerHeading": "",  // empty = no header shown
 
     "privacyUrl": "Gizlilik Politikası",
 

--- a/lang/tarteaucitron.uk.js
+++ b/lang/tarteaucitron.uk.js
@@ -16,6 +16,7 @@ tarteaucitron.lang = {
     "personalize": "Налаштувати",
     "close": "Закрити",
     "closeBanner": "Приховати банер cookie",
+    "bannerHeading": "",  // empty = no header shown
 
     "privacyUrl": "Політика конфіденційності",
 

--- a/lang/tarteaucitron.vi.js
+++ b/lang/tarteaucitron.vi.js
@@ -16,6 +16,7 @@ tarteaucitron.lang = {
     "personalize": "Cá nhân",
     "close": "Đóng",
     "closeBanner": "Ẩn biểu ngữ cookie",
+    "bannerHeading": "",  // empty = no header shown
 
     "privacyUrl": "Chính sách bảo mật",
 

--- a/lang/tarteaucitron.zh.js
+++ b/lang/tarteaucitron.zh.js
@@ -16,6 +16,7 @@ tarteaucitron.lang = {
     "personalize": "个性化",
     "close": "关闭",
     "closeBanner": "隐藏 cookie 横幅",
+    "bannerHeading": "",  // empty = no header shown
 
     "privacyUrl": "保密政策",
 

--- a/tarteaucitron.js
+++ b/tarteaucitron.js
@@ -252,7 +252,8 @@ var tarteaucitron = {
                 "dataLayer": false,
                 "serverSide": false,
                 "partnersList": false,
-                "alwaysNeedConsent": false
+                "alwaysNeedConsent": false,
+                "bannerHeading": "",  /* Optional heading text in the cookie banner (uses lang key "bannerHeading" if empty) */
             },
             params = tarteaucitron.parameters;
 
@@ -711,6 +712,11 @@ var tarteaucitron = {
                 if (tarteaucitron.parameters.highPrivacy && !tarteaucitron.parameters.AcceptAllCta) {
                     html += '<div tabindex="-1" id="tarteaucitronAlertBig" class="tarteaucitronAlertBig' + orientation + '"' + modalAttrs + '>';
                     //html += '<div class="tarteaucitronAlertBigWrapper">';
+                    // Optional translatable banner heading
+                    var headingText = tarteaucitron.parameters.bannerHeading || tarteaucitron.lang.bannerHeading || '';
+                    if (headingText !== '') {
+                        html += '   <span id="tarteaucitronBannerHeading" class="tarteaucitronBannerHeading" role="heading" aria-level="2">' + headingText + '</span>';
+                    }
                     html += '   <span id="tarteaucitronDisclaimerAlert" role="paragraph">';
                     html += '       ' + tarteaucitron.lang.alertBigPrivacy;
                     html += '   </span>';
@@ -731,6 +737,11 @@ var tarteaucitron = {
                 } else {
                     html += '<div tabindex="-1" id="tarteaucitronAlertBig" class="tarteaucitronAlertBig' + orientation + '"' + modalAttrs + '>';
                     //html += '<div class="tarteaucitronAlertBigWrapper">';
+                    // Optional translatable banner heading
+                    var headingText = tarteaucitron.parameters.bannerHeading || tarteaucitron.lang.bannerHeading || '';
+                    if (headingText !== '') {
+                        html += '   <span id="tarteaucitronBannerHeading" class="tarteaucitronBannerHeading" role="heading" aria-level="2">' + headingText + '</span>';
+                    }
                     html += '   <span id="tarteaucitronDisclaimerAlert" role="paragraph">';
 
                     if (tarteaucitron.parameters.highPrivacy) {
@@ -1169,6 +1180,11 @@ var tarteaucitron = {
             html += '<li id="' + service.key + 'Line" class="tarteaucitronLine">';
             html += '   <div class="tarteaucitronName">';
             html += '       <span class="tarteaucitronH3" role="heading" aria-level="4">' + service.name + '</span>';
+            // Optional translatable service description
+            var serviceDesc = tarteaucitron.lang['desc-' + service.key] || service.description || '';
+            if (serviceDesc !== '') {
+                html += '       <span class="tarteaucitronServiceDescription">' + serviceDesc + '</span>';
+            }
             html += '       <div class="tarteaucitronStatusInfo">';
             html += '          <span class="tacCurrentStatus" id="tacCurrentStatus' + service.key + '">'+currentStatus+'</span>';
             html += '          <span class="tarteaucitronReadmoreSeparator"> - </span>';


### PR DESCRIPTION
Our Data Protection Officer has pointed out that there is no heading in the cookie consent bar and no detailed descriptions of the services. According to him that would be required. We would like to add these. Here is a proposal for implementing this, which is fully backwards-compatible (optional).